### PR TITLE
fix block-sign-up for dashboards

### DIFF
--- a/react/assets/forus-platform/scss/_common/dashboard.scss
+++ b/react/assets/forus-platform/scss/_common/dashboard.scss
@@ -38,7 +38,11 @@
     @import 'blocks/block-provider-product';
     @import 'blocks/block-notifications';
     @import '../../../forus-webshop/scss/_common/components/ui-controls';
-    @import '../../../forus-webshop/scss/_common/sections/blocks/block-sign_up';
+}
+
+@import '../../../forus-webshop/scss/_common/sections/blocks/block-sign_up';
+
+.block {
     @import 'blocks/block-fund_types';
     @import 'blocks/block-subsidy-product-overview';
     @import 'blocks/block-app_download.scss';


### PR DESCRIPTION
## Changes description & testing suggestions
Due to changes in the scss blocks structure on webshops (fixing the bundle building time/size), the sign-up pages panels stoped showing properly.
<img width="1799" alt="image" src="https://github.com/teamforus/forus-frontend-react/assets/25606248/6e5a6049-5439-4e12-91b8-e4038e03a99a">

<!---
Add tag if PR:
- [ ] *Needs Translations* @lexlog @irinaBerendeeva87
- [ ] *Could affect implementations custom css* @lexlog @irinaBerendeeva87
-->

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## QA checklist
- *Check regress in implementations custom css* - changes are not breaking other implementations designes
- Feature is tested in different screen sizes - desktop, mobile
- WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- Translations are done
