### PR TITLE
release 118 fixes: part 2

### DIFF
--- a/react/assets/forus-platform/scss/_common/blocks/block-financial-dashboard.scss
+++ b/react/assets/forus-platform/scss/_common/blocks/block-financial-dashboard.scss
@@ -50,7 +50,7 @@
                             input {
                                 height: 30px;
                                 border: 1px solid #d4d9dd;
-                                background-image: assetUrl('/img/looking-glass.png');
+                                background-image: assetUrl('img/looking-glass.png');
                                 background-repeat: no-repeat;
                                 background-size: auto 120%;
                                 background-position: 100% 50%;

--- a/react/assets/forus-platform/scss/_common/components/forms.scss
+++ b/react/assets/forus-platform/scss/_common/components/forms.scss
@@ -1017,15 +1017,14 @@
             border: 2px solid #305dfb;
             position: relative;
             margin-right: 5px;
-            float: left;
             border-radius: 20px;
             margin-left: -30px;
 
             &::before {
                 content: '';
                 @include fill_parent(-2px);
+                border: 5px solid #305dfb;
                 border-radius: inherit;
-                border: 5px inherit;
                 opacity: 0;
                 transition: 0.4s;
             }

--- a/react/src/dashboard/components/elements/auth2fa-restriction/Auth2FARestriction.tsx
+++ b/react/src/dashboard/components/elements/auth2fa-restriction/Auth2FARestriction.tsx
@@ -1,9 +1,8 @@
 import React, { useMemo } from 'react';
 import useAssetUrl from '../../../hooks/useAssetUrl';
-import { NavLink } from 'react-router-dom';
-import { getStateRouteUrl } from '../../../modules/state_router/Router';
 import { get } from 'lodash';
 import Fund from '../../../props/models/Fund';
+import StateNavLink from '../../../modules/state_router/StateNavLink';
 
 export default function Auth2FARestriction({
     type,
@@ -46,10 +45,10 @@ export default function Auth2FARestriction({
                             accountaanpassingen kunnen worden gemaakt.
                         </div>
                         <div className="button-group">
-                            <NavLink className="button button-primary button-sm" to={getStateRouteUrl('security-2fa')}>
-                                <div className="icon-start mdi mdi-lock-outline"></div>
+                            <StateNavLink className="button button-primary button-sm" name={'security-2fa'}>
+                                <div className="icon-start mdi mdi-lock-outline" />
                                 Tweefactorauthenticatie instellen
-                            </NavLink>
+                            </StateNavLink>
                         </div>
                     </div>
                 )}
@@ -66,10 +65,10 @@ export default function Auth2FARestriction({
                             accountaanpassingen kunnen worden gemaakt.
                         </div>
                         <div className="button-group">
-                            <NavLink className="button button-primary button-sm" to={getStateRouteUrl('security-2fa')}>
+                            <StateNavLink className="button button-primary button-sm" name={'security-2fa'}>
                                 <div className="icon-start mdi mdi-lock-outline" />
                                 Tweefactorauthenticatie instellen
-                            </NavLink>
+                            </StateNavLink>
                         </div>
                     </div>
                 )}
@@ -86,10 +85,10 @@ export default function Auth2FARestriction({
                             accountaanpassingen kunnen worden gemaakt.
                         </div>
                         <div className="button-group">
-                            <NavLink className="button button-primary button-sm" to={getStateRouteUrl('security-2fa')}>
+                            <StateNavLink className="button button-primary button-sm" name={'security-2fa'}>
                                 <div className="icon-start mdi mdi-lock-outline" />
                                 Tweefactorauthenticatie instellen
-                            </NavLink>
+                            </StateNavLink>
                         </div>
                     </div>
                 )}

--- a/react/src/dashboard/components/elements/select-control/templates/SelectControlOptions.tsx
+++ b/react/src/dashboard/components/elements/select-control/templates/SelectControlOptions.tsx
@@ -32,7 +32,7 @@ export default function SelectControlOptions<T>({
     return (
         <div
             id={id}
-            className={`select-control ${disabled ? 'disabled' : ''} ${className ? className : ''}`}
+            className={`form-control select-control ${disabled ? 'disabled' : ''} ${className ? className : ''}`}
             tabIndex={0}
             role="button"
             data-dusk={dusk}

--- a/react/src/dashboard/components/elements/select-control/templates/SelectControlOptionsOrganization.tsx
+++ b/react/src/dashboard/components/elements/select-control/templates/SelectControlOptionsOrganization.tsx
@@ -3,9 +3,12 @@ import ClickOutside from '../../click-outside/ClickOutside';
 import { uniqueId } from 'lodash';
 import { SelectControlOptionsProp } from '../SelectControl';
 import Organization from '../../../../props/models/Organization';
-import { NavLink } from 'react-router-dom';
-import { getStateRouteUrl } from '../../../../modules/state_router/Router';
 import useThumbnailUrl from '../../../../hooks/useThumbnailUrl';
+import StateNavLink from '../../../../modules/state_router/StateNavLink';
+import useTranslate from '../../../../hooks/useTranslate';
+import useActiveOrganization from '../../../../hooks/useActiveOrganization';
+import { hasPermission } from '../../../../helpers/utils';
+import useIsSponsorPanel from '../../../../hooks/useIsSponsorPanel';
 
 export default function SelectControlOptionsOrganization<T>({
     query,
@@ -24,6 +27,10 @@ export default function SelectControlOptionsOrganization<T>({
     searchInputChanged,
     onOptionsScroll,
 }: SelectControlOptionsProp<T>) {
+    const translate = useTranslate();
+    const isSponsorPanel = useIsSponsorPanel();
+    const activeOrganization = useActiveOrganization();
+
     const [controlId] = useState('select_control_' + uniqueId());
     const thumbnailUrl = useThumbnailUrl();
     const input = useRef(null);
@@ -152,27 +159,47 @@ export default function SelectControlOptionsOrganization<T>({
                         </div>
 
                         <div className="select-control-options-actions">
-                            <NavLink
-                                to={getStateRouteUrl('organizations-edit', {
-                                    organizationId: (modelValue?.raw as Organization)?.id,
-                                })}
-                                onClick={() => setShowOptions(false)}
-                                className="select-control-switcher-setting">
-                                <div className="select-control-switcher-setting-icon">
-                                    <em className="mdi mdi-cog" />
-                                </div>
-                                <div className="select-control-switcher-setting-name">Organisatie instellingen</div>
-                            </NavLink>
+                            {isSponsorPanel && hasPermission(activeOrganization, 'manage_organization') && (
+                                <StateNavLink
+                                    name={'organizations-contacts'}
+                                    params={{ organizationId: (modelValue?.raw as Organization)?.id }}
+                                    onClick={() => setShowOptions(false)}
+                                    className="select-control-switcher-setting">
+                                    <div className="select-control-switcher-setting-icon">
+                                        <em className="mdi mdi-email-edit-outline" />
+                                    </div>
+                                    <div className="select-control-switcher-setting-name">
+                                        {translate('organizations.buttons.contacts')}
+                                    </div>
+                                </StateNavLink>
+                            )}
 
-                            <NavLink
-                                to={getStateRouteUrl('organizations-create')}
+                            {hasPermission(activeOrganization, 'manage_organization') && (
+                                <StateNavLink
+                                    name={'organizations-edit'}
+                                    params={{ organizationId: (modelValue?.raw as Organization)?.id }}
+                                    onClick={() => setShowOptions(false)}
+                                    className="select-control-switcher-setting">
+                                    <div className="select-control-switcher-setting-icon">
+                                        <em className="mdi mdi-cog" />
+                                    </div>
+                                    <div className="select-control-switcher-setting-name">
+                                        {translate('organizations.buttons.edit')}
+                                    </div>
+                                </StateNavLink>
+                            )}
+
+                            <StateNavLink
+                                name={'organizations-create'}
                                 onClick={() => setShowOptions(false)}
                                 className="select-control-switcher-setting">
                                 <div className="select-control-switcher-setting-icon">
                                     <em className="mdi mdi-plus-circle" />
                                 </div>
-                                <div className="select-control-switcher-setting-name">Organisatie toevoegen</div>
-                            </NavLink>
+                                <div className="select-control-switcher-setting-name">
+                                    {translate('organizations.buttons.add')}
+                                </div>
+                            </StateNavLink>
                         </div>
                     </ClickOutside>
                 )}

--- a/react/src/dashboard/components/modals/ModalCreatePrevalidation.tsx
+++ b/react/src/dashboard/components/modals/ModalCreatePrevalidation.tsx
@@ -14,6 +14,7 @@ import { ResponseError } from '../../props/ApiResponses';
 import { dateFormat, dateParse } from '../../helpers/dates';
 import useSetProgress from '../../hooks/useSetProgress';
 import usePushDanger from '../../hooks/usePushDanger';
+import TableEmptyValue from '../elements/table-empty-value/TableEmptyValue';
 
 export default function ModalCreatePrevalidation({
     fund,
@@ -183,7 +184,7 @@ export default function ModalCreatePrevalidation({
                                                     {form.values[fundRecord] ? (
                                                         form.values[fundRecord]
                                                     ) : (
-                                                        <span className={'text-muted'}>-</span>
+                                                        <TableEmptyValue />
                                                     )}
                                                 </div>
                                             </div>

--- a/react/src/dashboard/components/pages/extra-payments-view/ExtraPaymentsView.tsx
+++ b/react/src/dashboard/components/pages/extra-payments-view/ExtraPaymentsView.tsx
@@ -15,6 +15,7 @@ import useExtraPaymentService from '../../../services/ExtraPaymentService';
 import ExtraPayment from '../../../props/models/ExtraPayment';
 import ReservationExtraPaymentDetails from '../reservations-view/elements/ReservationExtraPaymentDetails';
 import useTranslate from '../../../hooks/useTranslate';
+import TableEmptyValue from '../../elements/table-empty-value/TableEmptyValue';
 
 export default function ExtraPaymentsView() {
     const { id } = useParams();
@@ -187,7 +188,7 @@ export default function ExtraPaymentsView() {
                                                     {extraPayment.reservation.accepted_at_locale}
                                                 </strong>
                                             ) : (
-                                                <span className="text-muted">-</span>
+                                                <TableEmptyValue />
                                             )}
                                         </td>
                                         <td>
@@ -200,7 +201,7 @@ export default function ExtraPaymentsView() {
                                                     {extraPayment.reservation.rejected_at_locale}
                                                 </strong>
                                             ) : (
-                                                <span className="text-muted">-</span>
+                                                <TableEmptyValue />
                                             )}
                                         </td>
                                     </tr>

--- a/react/src/dashboard/components/pages/extra-payments/ExtraPayments.tsx
+++ b/react/src/dashboard/components/pages/extra-payments/ExtraPayments.tsx
@@ -19,14 +19,18 @@ import { useFundService } from '../../../services/FundService';
 import usePaginatorService from '../../../modules/paginator/services/usePaginatorService';
 import EmptyCard from '../../elements/empty-card/EmptyCard';
 import useTranslate from '../../../hooks/useTranslate';
+import usePushApiError from '../../../hooks/usePushApiError';
 
 export default function ExtraPayments() {
-    const translate = useTranslate();
-    const fundService = useFundService();
     const activeOrganization = useActiveOrganization();
-    const extraPaymentService = useExtraPaymentService();
+
+    const translate = useTranslate();
     const setProgress = useSetProgress();
+    const pushApiError = usePushApiError('organization-no-permissions');
+
+    const fundService = useFundService();
     const paginatorService = usePaginatorService();
+    const extraPaymentService = useExtraPaymentService();
 
     const [loading, setLoading] = useState(false);
     const [paginatorKey] = useState('extra_payments');
@@ -49,11 +53,12 @@ export default function ExtraPayments() {
         extraPaymentService
             .list(activeOrganization.id, filter.activeValues)
             .then((res) => setExtraPayments(res.data))
+            .catch(pushApiError)
             .finally(() => {
                 setLoading(false);
                 setProgress(100);
             });
-    }, [extraPaymentService, activeOrganization.id, setProgress, filter?.activeValues]);
+    }, [extraPaymentService, activeOrganization.id, setProgress, filter?.activeValues, pushApiError]);
 
     const fetchFunds = useCallback(
         async (query: object): Promise<Array<Fund>> => {

--- a/react/src/dashboard/components/pages/fund-provider/elements/SubsidyFundProducts.tsx
+++ b/react/src/dashboard/components/pages/fund-provider/elements/SubsidyFundProducts.tsx
@@ -111,15 +111,6 @@ export default function SubsidyFundProducts({
                 </div>
             </div>
 
-            {fundProvider.allow_products && products.meta.total > 0 && (
-                <div className="card-section card-section-success card-section-narrow">
-                    <em>
-                        U kunt niet individuele producten uitzetten terwijl een globale instelling aan staat. Zet de
-                        globale instelling uit om individuele producten goed te keuren.
-                    </em>
-                </div>
-            )}
-
             {products.meta.total > 0 ? (
                 <div className="card-section card-section-padless">
                     <div className="table-wrapper">

--- a/react/src/dashboard/components/pages/implementations-notifications-send/ImplementationsNotificationsSend.tsx
+++ b/react/src/dashboard/components/pages/implementations-notifications-send/ImplementationsNotificationsSend.tsx
@@ -9,7 +9,7 @@ import { PaginationData, ResponseError, ResponseErrorData } from '../../../props
 import useImplementationService from '../../../services/ImplementationService';
 import { useParams } from 'react-router-dom';
 import Implementation from '../../../props/models/Implementation';
-import { getStateRouteUrl, useNavigateState } from '../../../modules/state_router/Router';
+import { useNavigateState } from '../../../modules/state_router/Router';
 import { hasPermission } from '../../../helpers/utils';
 import SelectControlOptions from '../../elements/select-control/templates/SelectControlOptions';
 import SelectControl from '../../elements/select-control/SelectControl';
@@ -122,8 +122,8 @@ export default function ImplementationsNotificationsSend() {
     });
 
     const exportIdentities = useCallback(() => {
-        fundIdentitiesExportService.exportData(activeOrganization.id, fund.id, identitiesFilters);
-    }, [activeOrganization?.id, fund?.id, fundIdentitiesExportService, identitiesFilters]);
+        fundIdentitiesExportService.exportData(activeOrganization.id, fund.id, identitiesFilters.activeValues);
+    }, [activeOrganization?.id, fund?.id, fundIdentitiesExportService, identitiesFilters.activeValues]);
 
     const onTemplateUpdated = useCallback(
         (item: SystemNotification) => {
@@ -235,12 +235,10 @@ export default function ImplementationsNotificationsSend() {
                     content: implementationNotificationsService.labelsToVars(template.content),
                 })
                 .then(() => {
-                    navigateState(
-                        getStateRouteUrl('implementation-notifications', {
-                            organizationId: activeOrganization.id,
-                            implementationId: implementation.id,
-                        }),
-                    );
+                    navigateState('implementation-notifications', {
+                        organizationId: activeOrganization.id,
+                        implementationId: implementation.id,
+                    });
 
                     pushSuccess('Gelukt!', 'De e-mail zal zo spoedig mogelijk verstuurd worden naar alle gebruikers.', {
                         timeout: 8000,
@@ -324,12 +322,10 @@ export default function ImplementationsNotificationsSend() {
             .read(activeOrganization.id, parseInt(id))
             .then((res) => {
                 if (!activeOrganization.allow_custom_fund_notifications) {
-                    navigateState(
-                        getStateRouteUrl('implementation-notifications', {
-                            organizationId: activeOrganization.id,
-                            implementationId: res.data.data.id,
-                        }),
-                    );
+                    navigateState('implementation-notifications', {
+                        organizationId: activeOrganization.id,
+                        implementationId: res.data.data.id,
+                    });
                 }
 
                 setImplementation(res.data.data);

--- a/react/src/dashboard/components/pages/implementations-notifications/ImplementationsNotifications.tsx
+++ b/react/src/dashboard/components/pages/implementations-notifications/ImplementationsNotifications.tsx
@@ -150,6 +150,16 @@ export default function ImplementationsNotifications() {
         }
     }, [fetchImplementationNotifications, implementation]);
 
+    if (implementations?.meta?.total === 0) {
+        return (
+            <EmptyCard
+                title={
+                    'De systeemberichten zijn niet beschikbaar, omdat er geen webshop configuratie is voor deze organisatie.'
+                }
+            />
+        );
+    }
+
     if (!implementations || !notificationGroups) {
         return <LoadingCard />;
     }
@@ -321,14 +331,6 @@ export default function ImplementationsNotifications() {
                     </div>
                 </div>
             ))}
-
-            {implementations?.meta.total == 0 && (
-                <EmptyCard
-                    title={
-                        'De systeemberichten zijn niet beschikbaar, omdat er geen webshop configuratie is voor deze organisatie.'
-                    }
-                />
-            )}
         </Fragment>
     );
 }

--- a/react/src/dashboard/components/pages/implementations-view/ImplementationsView.tsx
+++ b/react/src/dashboard/components/pages/implementations-view/ImplementationsView.tsx
@@ -127,7 +127,7 @@ export default function ImplementationsView() {
                             </StateNavLink>
                         )}
 
-                        {hasPermission(activeOrganization, ['manage_implementation', 'manage_implementation_cms']) && (
+                        {hasPermission(activeOrganization, ['manage_implementation_cms']) && (
                             <StateNavLink
                                 name={'implementations-cms'}
                                 params={{ id: implementation.id, organizationId: implementation.organization_id }}

--- a/react/src/dashboard/components/pages/implementations/Implementations.tsx
+++ b/react/src/dashboard/components/pages/implementations/Implementations.tsx
@@ -141,7 +141,7 @@ export default function Implementations() {
                             </StateNavLink>
                         )}
 
-                        {hasPermission(activeOrganization, ['manage_implementation', 'manage_implementation_cms']) && (
+                        {hasPermission(activeOrganization, ['manage_implementation_cms']) && (
                             <StateNavLink
                                 name={'implementations-cms'}
                                 params={{ id: implementation.id, organizationId: activeOrganization.id }}

--- a/react/src/dashboard/components/pages/organizations-contacts/OrganizationsContacts.tsx
+++ b/react/src/dashboard/components/pages/organizations-contacts/OrganizationsContacts.tsx
@@ -1,0 +1,185 @@
+import React, { useContext, useState } from 'react';
+import useActiveOrganization from '../../../hooks/useActiveOrganization';
+import { useOrganizationService } from '../../../services/OrganizationService';
+import StateNavLink from '../../../modules/state_router/StateNavLink';
+import useTranslate from '../../../hooks/useTranslate';
+import useFormBuilder from '../../../hooks/useFormBuilder';
+import FormError from '../../elements/forms/errors/FormError';
+import classNames from 'classnames';
+import usePushSuccess from '../../../hooks/usePushSuccess';
+import usePushApiError from '../../../hooks/usePushApiError';
+import { ResponseError } from '../../../props/ApiResponses';
+import { mainContext } from '../../../contexts/MainContext';
+import useSetProgress from '../../../hooks/useSetProgress';
+
+export default function OrganizationsContacts() {
+    const activeOrganization = useActiveOrganization();
+    const { setOrganizationData } = useContext(mainContext);
+
+    const translate = useTranslate();
+    const setProgress = useSetProgress();
+    const pushSuccess = usePushSuccess();
+    const pushApiError = usePushApiError();
+
+    const organizationService = useOrganizationService();
+
+    const [shownInfoBoxes, setShownInfoBoxes] = useState<Array<string>>([]);
+
+    const [available] = useState([
+        { key: 'fund_balance_low', type: 'email' },
+        { key: 'bank_connections_expiring', type: 'email' },
+        { key: 'provider_applied', type: 'email' },
+    ]);
+
+    const form = useFormBuilder(
+        {
+            contacts: available.map((type) => ({
+                ...type,
+                ...activeOrganization.contacts.find((contact) => contact.key === type.key),
+            })),
+        },
+        () => {
+            setProgress(0);
+
+            organizationService
+                .update(activeOrganization.id, form.values)
+                .then((res) => {
+                    setOrganizationData(activeOrganization.id, { contacts: res.data.data.contacts });
+                    pushSuccess('Opgeslagen!');
+                })
+                .catch((err: ResponseError) => {
+                    form.setErrors(err.data.errors);
+                    pushApiError(err);
+                })
+                .finally(() => {
+                    form.setIsLocked(false);
+                    setProgress(100);
+                });
+        },
+    );
+
+    return (
+        <div className="card">
+            <form className="form" onSubmit={form.submit}>
+                <div className="card-header">
+                    <div className="card-title">{translate('organization_contacts.title')}</div>
+                </div>
+                <div className="card-section card-section-primary">
+                    <div className="row">
+                        <div className="col col-lg-9 col-sm-12">
+                            {form.values.contacts?.map((contact, index) => (
+                                <div key={contact.key} className="form-group form-group-inline">
+                                    <label className="form-label">
+                                        {translate(`organization_contacts.labels.${contact.key}`)}
+                                    </label>
+                                    <div className="form-offset">
+                                        <div className="form-group-info">
+                                            <div className="form-group-info-control">
+                                                <div className="flex flex-grow flex-vertical">
+                                                    <input
+                                                        className="form-control"
+                                                        value={contact.value || ''}
+                                                        type={contact.type}
+                                                        onChange={(e) => {
+                                                            form.values.contacts[index].value = e.target.value;
+                                                            form.update({ ...form.values });
+                                                        }}
+                                                        placeholder={translate(
+                                                            'organization_contacts.labels.' + contact.key,
+                                                        )}
+                                                    />
+                                                    <FormError error={form.errors?.[`contacts.${index}.value`]} />
+                                                </div>
+                                            </div>
+                                            <div className="form-group-info-button">
+                                                <div
+                                                    className={classNames(
+                                                        'button',
+                                                        'button-default',
+                                                        'button-icon',
+                                                        'pull-left',
+                                                        shownInfoBoxes.includes(contact.key) && 'active',
+                                                    )}
+                                                    onClick={() => {
+                                                        setShownInfoBoxes((list) => {
+                                                            if (list.includes(contact.key)) {
+                                                                list.splice(list.indexOf(contact.key), 1);
+                                                            } else {
+                                                                list.push(contact.key);
+                                                            }
+
+                                                            return [...list];
+                                                        });
+                                                    }}>
+                                                    <em className="mdi mdi-information" />
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        {shownInfoBoxes.includes(contact.key) && (
+                                            <div className="block block-info-box block-info-box-primary">
+                                                <div className="info-box-icon mdi mdi-information" />
+                                                {contact.key == 'fund_balance_low' && (
+                                                    <div className="info-box-content">
+                                                        <div className="block block-markdown">
+                                                            <h4>Laag saldo op het fonds</h4>
+                                                            <p>
+                                                                Vul hier een e-mailadres in dat een notificatie krijgt
+                                                                wanneer het saldo op het fonds te laag is. Dit kan ook
+                                                                een e-mailadres zijn dat geen medewerker is van de
+                                                                organisatie.
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                )}
+
+                                                {contact.key == 'bank_connections_expiring' && (
+                                                    <div className="info-box-content">
+                                                        <div className="block block-markdown">
+                                                            <h4>Bank integratie verloopt</h4>
+                                                            <p>
+                                                                Vul hier een e-mailadres in dat een notificatie krijgt
+                                                                wanneer de huidige bank integratie verloopt. Dit kan ook
+                                                                een e-mailadres zijn dat geen medewerker is van de
+                                                                organisatie.
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                )}
+
+                                                {contact.key == 'provider_applied' && (
+                                                    <div className="info-box-content">
+                                                        <div className="block block-markdown">
+                                                            <h4>Aanbieder heeft zich aangemeld</h4>
+                                                            <p>
+                                                                Vul hier een e-mailadres in dat een notificatie krijgt
+                                                                wanneer een aanbieder zich heeft aangemeld voor een
+                                                                fonds. Dit kan ook een e-mailadres zijn dat geen
+                                                                medewerker is van de organisatie.
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+
+                <div className="card-section card-section-primary">
+                    <div className="text-center">
+                        <StateNavLink name={'organizations'} className="button button-default" id="cancel">
+                            {translate('organization_contacts.buttons.cancel')}
+                        </StateNavLink>
+                        <button className="button button-primary" type="submit">
+                            {translate('organization_contacts.buttons.submit')}
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/react/src/dashboard/components/pages/organizations-funds/OrganizationFunds.tsx
+++ b/react/src/dashboard/components/pages/organizations-funds/OrganizationFunds.tsx
@@ -24,10 +24,10 @@ import useOpenModal from '../../../hooks/useOpenModal';
 import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 import Paginator from '../../../modules/paginator/components/Paginator';
 import EmptyCard from '../../elements/empty-card/EmptyCard';
-import { useNavigateState } from '../../../modules/state_router/Router';
 import ModalFundTopUp from '../../modals/ModalFundTopUp';
 import useTranslate from '../../../hooks/useTranslate';
 import useAssetUrl from '../../../hooks/useAssetUrl';
+import TableEmptyValue from '../../elements/table-empty-value/TableEmptyValue';
 
 export default function OrganizationFunds() {
     const translate = useTranslate();
@@ -36,7 +36,6 @@ export default function OrganizationFunds() {
     const pushSuccess = usePushSuccess();
     const assetUrl = useAssetUrl();
     const openModal = useOpenModal();
-    const navigateState = useNavigateState();
     const activeOrganization = useActiveOrganization();
 
     const fundService = useFundService();
@@ -381,15 +380,12 @@ export default function OrganizationFunds() {
 
                                 <tbody>
                                     {funds.data.map((fund) => (
-                                        <tr
+                                        <StateNavLink
                                             key={fund.id}
-                                            className={'cursor-pointer'}
-                                            onClick={() =>
-                                                navigateState('funds-show', {
-                                                    organizationId: activeOrganization.id,
-                                                    fundId: fund.id,
-                                                })
-                                            }>
+                                            name={'funds-show'}
+                                            params={{ organizationId: activeOrganization.id, fundId: fund.id }}
+                                            customElement={'tr'}
+                                            className={'cursor-pointer'}>
                                             <td>
                                                 <div className="td-entity-main">
                                                     <div className="td-entity-main-media">
@@ -414,7 +410,9 @@ export default function OrganizationFunds() {
                                                 </div>
                                             </td>
 
-                                            <td className="text-strong text-muted-dark">{fund.implementation?.name}</td>
+                                            <td className="text-strong text-muted-dark">
+                                                {fund?.implementation?.name || <TableEmptyValue />}
+                                            </td>
 
                                             {funds_type == 'active' && (
                                                 <Fragment>
@@ -434,12 +432,14 @@ export default function OrganizationFunds() {
                                             )}
 
                                             <td>
-                                                {!fund.archived && stateLabels[fund.state] && (
+                                                {!fund.archived && stateLabels[fund.state] ? (
                                                     <span className={`label ${stateLabels[fund.state] || ''}`}>
                                                         {translate(
                                                             `components.organization_funds.states.${fund.state}`,
                                                         )}
                                                     </span>
+                                                ) : (
+                                                    <TableEmptyValue />
                                                 )}
 
                                                 {fund.archived && (
@@ -544,7 +544,7 @@ export default function OrganizationFunds() {
                                                     )
                                                 )}
                                             </td>
-                                        </tr>
+                                        </StateNavLink>
                                     ))}
                                 </tbody>
                             </table>

--- a/react/src/dashboard/components/pages/organizations-view/OrganizationsView.tsx
+++ b/react/src/dashboard/components/pages/organizations-view/OrganizationsView.tsx
@@ -1,14 +1,14 @@
 import React, { useContext, useEffect } from 'react';
 import { useOrganizationService } from '../../../services/OrganizationService';
-import { useNavigate, useParams } from 'react-router-dom';
-import { getStateRouteUrl } from '../../../modules/state_router/Router';
+import { useParams } from 'react-router-dom';
+import { useNavigateState } from '../../../modules/state_router/Router';
 import { mainContext } from '../../../contexts/MainContext';
 
 export default function OrganizationsView() {
     const { id } = useParams();
     const { fetchOrganizations, setOrganizations, setActiveOrganization } = useContext(mainContext);
     const organizationService = useOrganizationService();
-    const navigate = useNavigate();
+    const navigateState = useNavigateState();
 
     useEffect(() => {
         fetchOrganizations().then((organizations) => {
@@ -20,9 +20,9 @@ export default function OrganizationsView() {
             }
 
             setOrganizations(organizations);
-            navigate(getStateRouteUrl('organizations'));
+            navigateState('organizations');
         });
-    }, [fetchOrganizations, navigate, organizationService, setActiveOrganization, setOrganizations, id]);
+    }, [fetchOrganizations, navigateState, organizationService, setActiveOrganization, setOrganizations, id]);
 
     return <></>;
 }

--- a/react/src/dashboard/components/pages/redirect/Redirect.tsx
+++ b/react/src/dashboard/components/pages/redirect/Redirect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { NavLink, useSearchParams } from 'react-router-dom';
-import { getStateRouteUrl } from '../../../modules/state_router/Router';
+import { useSearchParams } from 'react-router-dom';
 import useAssetUrl from '../../../hooks/useAssetUrl';
+import StateNavLink from '../../../modules/state_router/StateNavLink';
 
 // todo: investigate
 export default function Redirect() {
@@ -25,12 +25,12 @@ export default function Redirect() {
                     </div>
 
                     <div className="block-email-confirmed-footer">
-                        <NavLink
-                            to={getStateRouteUrl('organizations')}
-                            data-dusk="identityEmailConfirmedButton"
+                        <StateNavLink
+                            name={'organizations'}
+                            dataDusk="identityEmailConfirmedButton"
                             className="button button-primary button-lg">
                             Bekijken
-                        </NavLink>
+                        </StateNavLink>
                     </div>
                 </div>
             </>

--- a/react/src/dashboard/components/pages/reimbursements/Reimbursements.tsx
+++ b/react/src/dashboard/components/pages/reimbursements/Reimbursements.tsx
@@ -27,6 +27,7 @@ import useSetProgress from '../../../hooks/useSetProgress';
 import LoadingCard from '../../elements/loading-card/LoadingCard';
 import useTranslate from '../../../hooks/useTranslate';
 import classNames from 'classnames';
+import TableEmptyValue from '../../elements/table-empty-value/TableEmptyValue';
 
 export default function Reimbursements() {
     const activeOrganization = useActiveOrganization();
@@ -488,9 +489,7 @@ export default function Reimbursements() {
                                                         </span>
                                                     )}
 
-                                                    {!reimbursement.voucher_transaction && (
-                                                        <span className="text-muted">-</span>
-                                                    )}
+                                                    {!reimbursement.voucher_transaction && <TableEmptyValue />}
                                                 </td>
 
                                                 <td>

--- a/react/src/dashboard/components/pages/reservations-view/ReservationsView.tsx
+++ b/react/src/dashboard/components/pages/reservations-view/ReservationsView.tsx
@@ -19,6 +19,7 @@ import TransactionDetails from '../transactions-view/elements/TransactionDetails
 import ReservationExtraPaymentRefunds from './elements/ReservationExtraPaymentRefunds';
 import ReservationExtraPaymentDetails from './elements/ReservationExtraPaymentDetails';
 import useTranslate from '../../../hooks/useTranslate';
+import TableEmptyValue from '../../elements/table-empty-value/TableEmptyValue';
 
 export default function ReservationsView() {
     const { id } = useParams();
@@ -289,7 +290,7 @@ export default function ReservationsView() {
                                             {reservation.accepted_at ? (
                                                 <strong className="text-black">{reservation.accepted_at_locale}</strong>
                                             ) : (
-                                                <span className="text-muted">-</span>
+                                                <TableEmptyValue />
                                             )}
                                         </td>
                                         <td>
@@ -300,7 +301,7 @@ export default function ReservationsView() {
                                             {reservation.rejected_at ? (
                                                 <strong className="text-black">{reservation.rejected_at_locale}</strong>
                                             ) : (
-                                                <span className="text-muted">-</span>
+                                                <TableEmptyValue />
                                             )}
                                         </td>
                                     </tr>

--- a/react/src/dashboard/components/pages/sponsor-fund-unsubscriptions/elements/SponsorFundUnsubscriptionTableItem.tsx
+++ b/react/src/dashboard/components/pages/sponsor-fund-unsubscriptions/elements/SponsorFundUnsubscriptionTableItem.tsx
@@ -5,6 +5,7 @@ import FundProviderUnsubscribe from '../../../../props/models/FundProviderUnsubs
 import useAssetUrl from '../../../../hooks/useAssetUrl';
 import StateNavLink from '../../../../modules/state_router/StateNavLink';
 import Tooltip from '../../../elements/tooltip/Tooltip';
+import TableEmptyValue from '../../../elements/table-empty-value/TableEmptyValue';
 
 export default function SponsorFundUnsubscriptionTableItem({
     organization,
@@ -69,7 +70,7 @@ export default function SponsorFundUnsubscriptionTableItem({
                         )}
                     </div>
                 ) : (
-                    <div className={'text-muted'}>-</div>
+                    <TableEmptyValue />
                 )}
             </td>
 

--- a/react/src/dashboard/components/pages/sponsor-provider-organization/elements/FundProviderTableItem.tsx
+++ b/react/src/dashboard/components/pages/sponsor-provider-organization/elements/FundProviderTableItem.tsx
@@ -1,11 +1,10 @@
 import React, { Fragment, useCallback, useState } from 'react';
 import { ResponseError } from '../../../../props/ApiResponses';
-import { NavLink } from 'react-router-dom';
 import usePushDanger from '../../../../hooks/usePushDanger';
 import { useFundService } from '../../../../services/FundService';
 import usePushSuccess from '../../../../hooks/usePushSuccess';
 import FundProvider from '../../../../props/models/FundProvider';
-import { getStateRouteUrl } from '../../../../modules/state_router/Router';
+import StateNavLink from '../../../../modules/state_router/StateNavLink';
 import Organization from '../../../../props/models/Organization';
 import useConfirmFundProviderUpdate from '../hooks/useConfirmFundProviderUpdate';
 import useAssetUrl from '../../../../hooks/useAssetUrl';
@@ -199,16 +198,17 @@ export default function FundProviderTableItem({
                         </button>
                     )}
 
-                <NavLink
-                    to={getStateRouteUrl('fund-provider', {
+                <StateNavLink
+                    name={'fund-provider'}
+                    params={{
                         id: fundProvider.id,
                         fundId: fundProvider.fund_id,
                         organizationId: organization.id,
-                    })}
+                    }}
                     className={`button button-sm button-default ${submittingState ? 'disabled' : ''}`}>
                     <em className="mdi mdi-eye-outline icon-start" />
                     Bekijk aanbod
-                </NavLink>
+                </StateNavLink>
             </td>
         </tr>
     );

--- a/react/src/dashboard/components/pages/transactions/Transactions.tsx
+++ b/react/src/dashboard/components/pages/transactions/Transactions.tsx
@@ -37,6 +37,7 @@ import usePaginatorService from '../../../modules/paginator/services/usePaginato
 import ClickOutside from '../../elements/click-outside/ClickOutside';
 import useTranslate from '../../../hooks/useTranslate';
 import classNames from 'classnames';
+import TableEmptyValue from '../../elements/table-empty-value/TableEmptyValue';
 
 export default function Transactions() {
     const envData = useEnvData();
@@ -975,7 +976,7 @@ export default function Transactions() {
                                                                     </div>
                                                                 </div>
                                                             ) : (
-                                                                <span className={'text-muted'}>-</span>
+                                                                <TableEmptyValue />
                                                             )}
                                                         </td>
                                                     )}

--- a/react/src/dashboard/components/pages/vouchers/ProductVouchers.tsx
+++ b/react/src/dashboard/components/pages/vouchers/ProductVouchers.tsx
@@ -374,7 +374,7 @@ export default function ProductVouchers() {
             {loading && <LoadingCard type={'card-section'} />}
 
             {!loading && vouchers.meta.total == 0 && (
-                <EmptyCard title={'Geen vouchers gevonden'} type={'card-section'} />
+                <EmptyCard title={'Geen aanbiedingsvouchers gevonden'} type={'card-section'} />
             )}
 
             {vouchers.meta && (

--- a/react/src/dashboard/components/pages/vouchers/elements/VouchersTableHeader.tsx
+++ b/react/src/dashboard/components/pages/vouchers/elements/VouchersTableHeader.tsx
@@ -108,7 +108,7 @@ export default function VouchersTableHeader({
                                 <button
                                     id="create_voucher"
                                     className="button button-primary"
-                                    disabled={funds.filter((fund) => fund.id)?.length < 1}
+                                    disabled={funds?.filter((fund) => fund.id)?.length < 1}
                                     onClick={() => createVoucher(funds, filter.activeValues?.fund_id, fetchVouchers)}>
                                     <em className="mdi mdi-plus-circle icon-start" />
                                     {translate('vouchers.buttons.add_new')}
@@ -117,7 +117,7 @@ export default function VouchersTableHeader({
                                 <button
                                     id="voucher_upload_csv"
                                     className="button button-primary"
-                                    disabled={funds.filter((fund) => fund.id)?.length < 1}
+                                    disabled={funds?.filter((fund) => fund.id)?.length < 1}
                                     onClick={() => uploadVouchers(funds, filter.activeValues?.fund_id, fetchVouchers)}
                                     data-dusk="uploadVouchersBatchButton">
                                     <em className="mdi mdi-upload icon-start" />

--- a/react/src/dashboard/contexts/MainContext.tsx
+++ b/react/src/dashboard/contexts/MainContext.tsx
@@ -13,11 +13,12 @@ interface AuthMemoProps {
     appConfigs?: AppConfigProp;
     setAppConfigs?: (appConfigs: AppConfigProp) => void;
     activeOrganization?: Organization;
-    setActiveOrganization: (organization: Organization) => void;
+    setActiveOrganization: React.Dispatch<React.SetStateAction<Organization>>;
     organizations?: Array<Organization>;
-    setOrganizations: (organization: Array<Organization>) => void;
+    setOrganizations: React.Dispatch<React.SetStateAction<Array<Organization>>>;
     clearAll: () => void;
     fetchOrganizations: () => Promise<Array<Organization> | null>;
+    setOrganizationData: (id: number, data: Partial<Organization>) => void;
 }
 
 const mainContext = createContext<AuthMemoProps>(null);
@@ -29,8 +30,8 @@ const MainProvider = ({ children }: { children: React.ReactElement }) => {
     const authIdentity = useAuthIdentity();
     const navigateState = useNavigateState();
 
-    const [organizations, setOrganizations] = useState(null);
-    const [activeOrganization, setActiveOrganization] = useState(null);
+    const [organizations, setOrganizations] = useState<Array<Organization>>(null);
+    const [activeOrganization, setActiveOrganization] = useState<Organization>(null);
 
     const configService = useConfigService();
     const organizationService = useOrganizationService();
@@ -58,6 +59,18 @@ const MainProvider = ({ children }: { children: React.ReactElement }) => {
         setOrganizations(null);
         return null;
     }, [authIdentity, envData, organizationService]);
+
+    const setOrganizationData = useCallback((id: number, data: Partial<Organization>) => {
+        setOrganizations((organizations) => {
+            const organization = organizations.find((item) => item.id === id);
+
+            if (organization) {
+                Object.assign(organization, data);
+            }
+
+            return [...organizations];
+        });
+    }, []);
 
     useEffect(() => {
         if (!envData?.type) {
@@ -100,6 +113,7 @@ const MainProvider = ({ children }: { children: React.ReactElement }) => {
                 organizations,
                 setOrganizations,
                 fetchOrganizations,
+                setOrganizationData,
             }}>
             {children}
         </Provider>

--- a/react/src/dashboard/hooks/useIsSponsorPanel.tsx
+++ b/react/src/dashboard/hooks/useIsSponsorPanel.tsx
@@ -1,0 +1,5 @@
+import useEnvData from './useEnvData';
+
+export default function useIsSponsorPanel() {
+    return useEnvData().client_type == 'sponsor';
+}

--- a/react/src/dashboard/hooks/usePushApiError.tsx
+++ b/react/src/dashboard/hooks/usePushApiError.tsx
@@ -1,14 +1,22 @@
 import usePushDanger from './usePushDanger';
 import { useCallback } from 'react';
 import { ResponseError } from '../props/ApiResponses';
+import { useNavigateState } from '../modules/state_router/Router';
+import useActiveOrganization from './useActiveOrganization';
 
-export default function usePushApiError() {
+export default function usePushApiError(redirectStateName?: string) {
     const pushDanger = usePushDanger();
+    const navigateSate = useNavigateState();
+    const activeOrganization = useActiveOrganization();
 
     return useCallback(
         (err: ResponseError) => {
             pushDanger('Mislukt!', err.data.message);
+
+            if (redirectStateName) {
+                return navigateSate(redirectStateName, { organizationId: activeOrganization?.id });
+            }
         },
-        [pushDanger],
+        [activeOrganization?.id, navigateSate, pushDanger, redirectStateName],
     );
 }

--- a/react/src/dashboard/layout/elements/aside/LayoutAsideNavItem.tsx
+++ b/react/src/dashboard/layout/elements/aside/LayoutAsideNavItem.tsx
@@ -1,7 +1,6 @@
 import { MouseEventHandler } from 'react';
-import { getStateRouteUrl } from '../../../modules/state_router/Router';
-import { NavLink } from 'react-router-dom';
 import React from 'react';
+import StateNavLink from '../../../modules/state_router/StateNavLink';
 
 interface IdentityMenuItemProps {
     id?: string;
@@ -26,15 +25,14 @@ export default function LayoutAsideNavItem({
     onClick,
     target,
 }: IdentityMenuItemProps) {
-    const to = getStateRouteUrl(route, routeParams);
-
     return (
         show && (
-            <NavLink
+            <StateNavLink
                 id={id}
                 onClick={onClick}
-                to={to || '/'}
-                data-dusk={dusk}
+                name={route}
+                params={routeParams}
+                dataDusk={dusk}
                 target={target}
                 className="sidebar-nav-item">
                 <div className="sidebar-nav-item-arrow">
@@ -47,7 +45,7 @@ export default function LayoutAsideNavItem({
                     <img src={`./assets/img/menu/icon-${icon}-active.svg`} alt="Item" className={'active'} />
                 </div>
                 {name}
-            </NavLink>
+            </StateNavLink>
         )
     );
 }

--- a/react/src/dashboard/layout/elements/aside/LayoutAsideSponsor.tsx
+++ b/react/src/dashboard/layout/elements/aside/LayoutAsideSponsor.tsx
@@ -13,6 +13,7 @@ export default function LayoutAsideSponsor({ organization }: { organization: Org
     return (
         <div className="sidebar-nav">
             <div className="sidebar-section-title">Organisatie</div>
+
             <LayoutAsideNavItem
                 name={'Fondsen'}
                 icon={'my_funds'}
@@ -119,40 +120,48 @@ export default function LayoutAsideSponsor({ organization }: { organization: Org
             {hasPermission(organization, 'view_finances') && (
                 <Fragment>
                     <div className="sidebar-section-title">{translate('menu.financial')}</div>
-                    <LayoutAsideNavItem
-                        name={'Overzicht'}
-                        icon={'financial_dashboard_overview'}
-                        route={'financial-dashboard-overview'}
-                        routeParams={{ organizationId: organization?.id }}
-                        show={true}
-                        id={'financial_dashboard_overview'}
-                    />
-                    <LayoutAsideNavItem
-                        name={'Statistieken'}
-                        icon={'financial_dashboard'}
-                        route={'financial-dashboard'}
-                        routeParams={{ organizationId: organization?.id }}
-                        show={true}
-                        id={'financial_dashboard'}
-                    />
-                    <LayoutAsideNavItem
-                        name={'Transacties'}
-                        icon={'transactions'}
-                        route={'transactions'}
-                        routeParams={{ organizationId: organization?.id }}
-                        show={true}
-                        id={'transactions'}
-                        dusk={'transactionsPage'}
-                    />
-                    <LayoutAsideNavItem
-                        name={'Bijbetalingen'}
-                        icon={'extra-payments'}
-                        route={'extra-payments'}
-                        routeParams={{ organizationId: organization?.id }}
-                        show={true}
-                        id={'extra-payments'}
-                        dusk={'extraPaymentsPage'}
-                    />
+
+                    {hasPermission(organization, 'view_finances') && (
+                        <Fragment>
+                            <LayoutAsideNavItem
+                                name={'Overzicht'}
+                                icon={'financial_dashboard_overview'}
+                                route={'financial-dashboard-overview'}
+                                routeParams={{ organizationId: organization?.id }}
+                                show={true}
+                                id={'financial_dashboard_overview'}
+                            />
+                            <LayoutAsideNavItem
+                                name={'Statistieken'}
+                                icon={'financial_dashboard'}
+                                route={'financial-dashboard'}
+                                routeParams={{ organizationId: organization?.id }}
+                                show={true}
+                                id={'financial_dashboard'}
+                            />
+                            <LayoutAsideNavItem
+                                name={'Transacties'}
+                                icon={'transactions'}
+                                route={'transactions'}
+                                routeParams={{ organizationId: organization?.id }}
+                                show={true}
+                                id={'transactions'}
+                                dusk={'transactionsPage'}
+                            />
+                        </Fragment>
+                    )}
+
+                    {hasPermission(organization, 'view_funds_extra_payments') && (
+                        <LayoutAsideNavItem
+                            name={'Bijbetalingen'}
+                            icon={'extra-payments'}
+                            route={'extra-payments'}
+                            routeParams={{ organizationId: organization?.id }}
+                            show={true}
+                            id={'extra-payments'}
+                            dusk={'extraPaymentsPage'}
+                        />
+                    )}
                 </Fragment>
             )}
 
@@ -183,6 +192,8 @@ export default function LayoutAsideSponsor({ organization }: { organization: Org
                     />
                 </Fragment>
             )}
+
+            <div className="sidebar-section-title">{translate('menu.personal')}</div>
 
             <LayoutAsideNavItem
                 name={'Feedback'}

--- a/react/src/dashboard/layout/elements/blocks/HeaderNotifications.tsx
+++ b/react/src/dashboard/layout/elements/blocks/HeaderNotifications.tsx
@@ -2,8 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import Organization from '../../../props/models/Organization';
 import { useNotificationService } from '../../../services/NotificationService';
 import ClickOutside from '../../../components/elements/click-outside/ClickOutside';
-import { NavLink } from 'react-router-dom';
-import { getStateRouteUrl } from '../../../modules/state_router/Router';
+import StateNavLink from '../../../modules/state_router/StateNavLink';
 import { PaginationData } from '../../../props/ApiResponses';
 import Notification from '../../../props/models/Notification';
 import useEnvData from '../../../hooks/useEnvData';
@@ -99,13 +98,14 @@ export default function HeaderNotifications({ organization }: { organization: Or
                             Nieuwe notificaties
                             {parseInt(notifications?.meta?.total_unseen?.toString()) > 0 &&
                                 ` (${notifications.meta.total_unseen} nieuw)`}
-                            <NavLink
-                                to={getStateRouteUrl('organization-notifications', { organizationId: organization.id })}
+                            <StateNavLink
+                                name={'organization-notifications'}
+                                params={{ organizationId: organization.id }}
                                 onClick={() => setShowNotifications(false)}
                                 className="notifications-menu-header-link">
                                 Bekijk alles
                                 <em className="mdi mdi-arrow-right" />
-                            </NavLink>
+                            </StateNavLink>
                         </div>
                         <div className="notifications-menu-body">
                             {notifications?.data.map((notification) => (

--- a/react/src/dashboard/props/models/Organization.tsx
+++ b/react/src/dashboard/props/models/Organization.tsx
@@ -88,6 +88,13 @@ export default interface Organization {
     allow_extra_payments_by_sponsor?: boolean;
     allow_provider_extra_payments?: boolean;
     can_receive_extra_payments?: boolean;
+    contacts?: Array<{
+        id?: number;
+        type?: 'email';
+        key?: string;
+        value?: string;
+        organization_id?: number;
+    }>;
     bank_statement_details?: {
         bank_transaction_id?: boolean;
         bank_transaction_date?: boolean;

--- a/react/src/dashboard/router/routes.tsx
+++ b/react/src/dashboard/router/routes.tsx
@@ -90,6 +90,7 @@ import ThrowError from '../components/pages_system/ThrowError';
 import Implementations from '../components/pages/implementations/Implementations';
 import ExternalValidators from '../components/pages/external-validators/ExternalValidators';
 import SponsorFundUnsubscriptions from '../components/pages/sponsor-fund-unsubscriptions/SponsorFundUnsubscriptions';
+import OrganizationsContacts from '../components/pages/organizations-contacts/OrganizationsContacts';
 
 const router = new RouterBuilder();
 
@@ -349,6 +350,11 @@ router.state('organization-logs', <EventLogs />, {
 
 router.state('bi-connection', <BiConnection />, {
     path: `/organizations/:organizationId/bi-connection`,
+    fallbackState: 'organizations',
+});
+
+router.state('organizations-contacts', <OrganizationsContacts />, {
+    path: `/organizations/:organizationId/contacts`,
     fallbackState: 'organizations',
 });
 


### PR DESCRIPTION
## Changes description & testing suggestions
- visual fix: fund edit page - activation type dropdown not looking disabled
- textual fix: product vouchers page empty block message saying "vouchers" instead of "product vouchers"
- financial dashboard fix "looking glass" icon url in css
- fix infinite loading on extra system notifications when you don't have any implementations: added proper message box
- fix infinite loading on extra payments page when you don't have permissions to access the page: added push and redirect
- visual fix: providers page filters - radio box options not showing active option
- fix: provider products list - remove "globally approved info box" for action funds
- fix: vouchers/product-vouchers table - white screen in some cases when funds list loading is not finished
- add missing organization contacts page and added menu item to organizations dropdown
- add missing "Persoonlijk" title in sidebar menu list
- hide CMS button for employees without permission to access the page on implementations list and details pages.
- fix fund custom message identities list export
- fix redirect after custom message sent

## Developers checklist
- [x] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed
<img width="844" alt="image" src="https://github.com/teamforus/forus-frontend-react/assets/25606248/2dd788c5-b0fb-414b-984e-1d031aaf522c">

## QA checklist
- *Check regress in implementations custom css* - changes are not breaking other implementations designes
- Feature is tested in different screen sizes - desktop, mobile
- WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- Translations are done
