### PR TITLE
add eslint errors to webpack builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.27.1",
         "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-webpack-plugin": "^4.2.0",
         "html-loader": "^4.2.0",
         "html-webpack-plugin": "^5.5.0",
         "prettier": "^2.4.1",
@@ -286,21 +287,23 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.21.4",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.8.tgz",
+      "integrity": "sha512-c4IM7OTg6k1Q+AJ153e2mc2QVTezTwnb4VzquwcyiEzGnW0Kedv4do/TrkU98qPeC5LNiMt/QXwIjzYXLBpyZg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -353,13 +356,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.6",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.8.tgz",
+      "integrity": "sha512-47DG+6F5SzOi0uEvK4wMShmn5yY0mVjVJoWTphdY2B4Rx9wHgjK7Yhtr0ru6nE+sn0v38mzrWOlah0p/YlHHOQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.23.6",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.24.8",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -367,24 +371,26 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.18.6",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+      "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -403,36 +409,36 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.21.4",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
+      "integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.21.4",
-        "@babel/helper-validator-option": "^7.21.0",
-        "browserslist": "^4.21.3",
+        "@babel/compat-data": "^7.24.8",
+        "@babel/helper-validator-option": "^7.24.8",
+        "browserslist": "^4.23.1",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.21.0",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.8.tgz",
+      "integrity": "sha512-4f6Oqnmyp2PP3olgUMmOwC3akxSm5aBYraQ6YDdKy7NcAMkDECHWG0DEnV6M2UAkERgIBhYt8S27rURPg7SxWA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.21.0",
-        "@babel/helper-member-expression-to-functions": "^7.21.0",
-        "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.20.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
-        "@babel/helper-split-export-declaration": "^7.18.6"
+        "@babel/helper-annotate-as-pure": "^7.24.7",
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-function-name": "^7.24.7",
+        "@babel/helper-member-expression-to-functions": "^7.24.8",
+        "@babel/helper-optimise-call-expression": "^7.24.7",
+        "@babel/helper-replace-supers": "^7.24.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -473,9 +479,13 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -492,45 +502,51 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.21.0",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
+      "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.21.0"
+        "@babel/traverse": "^7.24.8",
+        "@babel/types": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -555,20 +571,22 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.18.6",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
+      "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -591,19 +609,20 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.20.7",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.7.tgz",
+      "integrity": "sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-member-expression-to-functions": "^7.20.7",
-        "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.7",
-        "@babel/types": "^7.20.7"
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-member-expression-to-functions": "^7.24.7",
+        "@babel/helper-optimise-call-expression": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
@@ -618,47 +637,53 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.20.0",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+      "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.0"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.23.4",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.21.0",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -691,22 +716,25 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.23.4",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.6",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1945,31 +1973,33 @@
       "license": "MIT"
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.7",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
+      "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.6",
-        "@babel/types": "^7.23.6",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.24.8",
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-function-name": "^7.24.7",
+        "@babel/helper-hoist-variables": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/parser": "^7.24.8",
+        "@babel/types": "^7.24.8",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1978,12 +2008,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.6",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.8.tgz",
+      "integrity": "sha512-SkSBEHwwJRU52QEVZBmMBnE5Ux2/6WU1grdYyOhpbCNxbmJrDuDCphBzKZSO3taf0zztp+qkWlymE5tVL5l0TA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.8",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -2217,22 +2248,24 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.5.0",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -2332,8 +2365,9 @@
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2363,11 +2397,12 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "license": "MIT",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@kurkle/color": {
@@ -2540,9 +2575,10 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.24",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
     },
     "node_modules/@smithy/eventstream-codec": {
       "version": "1.1.0",
@@ -3251,8 +3287,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.21.3",
-      "license": "MIT",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4514,8 +4551,9 @@
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -4579,12 +4617,16 @@
       }
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-array-buffer": "^3.0.1"
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4596,14 +4638,16 @@
       "license": "MIT"
     },
     "node_modules/array-includes": {
-      "version": "3.1.6",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -4629,13 +4673,14 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.1",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -4655,6 +4700,28 @@
         "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0",
         "get-intrinsic": "^1.1.3"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
+        "is-shared-array-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/asn1.js": {
@@ -4701,9 +4768,13 @@
       "license": "ISC"
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5179,7 +5250,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
+      "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5188,14 +5261,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001640",
+        "electron-to-chromium": "^1.4.820",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5241,12 +5317,19 @@
       "license": "MIT"
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5289,9 +5372,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001589",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
-      "integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
+      "version": "1.0.30001641",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz",
+      "integrity": "sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5323,8 +5406,9 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -5479,16 +5563,18 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -5742,11 +5828,12 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.29.1",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
+      "integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.5"
+        "browserslist": "^4.23.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6019,6 +6106,57 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "license": "MIT",
@@ -6118,6 +6256,23 @@
         "node": ">= 10"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "dev": true,
@@ -6127,10 +6282,12 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -6439,8 +6596,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.337",
-      "license": "ISC"
+      "version": "1.4.825",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.825.tgz",
+      "integrity": "sha512-OCcF+LwdgFGcsYPYC5keEEFC2XT0gBhrYbeGzHCx7i9qRFbzO/AqTmc/C/1xNhJj+JA7rzlN7mpBuStshh96Cg=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -6521,50 +6679,84 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.21.2",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-set-tostringtag": "^2.0.1",
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
         "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.2.0",
-        "get-symbol-description": "^1.0.0",
+        "function.prototype.name": "^1.1.6",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-proto": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.5",
-        "is-array-buffer": "^3.0.2",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
         "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
+        "is-shared-array-buffer": "^1.0.3",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.10",
+        "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.3",
+        "object-inspect": "^1.13.1",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.4.3",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.7",
-        "string.prototype.trimend": "^1.0.6",
-        "string.prototype.trimstart": "^1.0.6",
-        "typed-array-length": "^1.0.4",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.6",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.9"
+        "which-typed-array": "^1.1.15"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-get-iterator": {
@@ -6590,25 +6782,39 @@
       "version": "0.9.3",
       "license": "MIT"
     },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.0.1",
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.1.3",
-        "has": "^1.0.3",
-        "has-tostringtag": "^1.0.0"
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       }
     },
     "node_modules/es-to-primitive": {
@@ -6628,8 +6834,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "license": "MIT",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "engines": {
         "node": ">=6"
       }
@@ -6641,8 +6848,9 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -6993,6 +7201,69 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-rsfpFQ01AWQbqtjgPRr2usVRxhWDuG0YDYcG8DJOteD3EFnpeuYuOwk0PQiN7PRBTqS6ElNdtPZPggj8If9WnA==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^8.56.10",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/eslint-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-webpack-plugin/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/eslint-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
@@ -7614,19 +7885,24 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
-      "license": "MIT"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.5",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7676,13 +7952,19 @@
       "license": "Apache-2.0"
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7700,12 +7982,14 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7841,20 +8125,22 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7874,11 +8160,12 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7925,6 +8212,18 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -8419,12 +8718,13 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.5",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.0",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       },
       "engines": {
@@ -8470,13 +8770,16 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.2",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
-        "is-typed-array": "^1.1.10"
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8541,11 +8844,30 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "dev": true,
+      "dependencies": {
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8629,9 +8951,10 @@
       }
     },
     "node_modules/is-negative-zero": {
-      "version": "2.0.2",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -8743,11 +9066,15 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8793,15 +9120,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.10",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "which-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9190,11 +9514,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -9963,8 +10288,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.10",
-      "license": "MIT"
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -10029,9 +10355,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.3",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10060,12 +10390,13 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
@@ -10090,13 +10421,15 @@
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.6",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10118,13 +10451,14 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.6",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
+      "integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10477,8 +10811,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "license": "ISC"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -10572,6 +10907,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -11173,13 +11517,15 @@
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11256,11 +11602,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -11379,6 +11726,24 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "funding": [
@@ -11398,13 +11763,17 @@
       "license": "MIT"
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.0",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11659,6 +12028,38 @@
       "version": "2.0.0",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -12051,13 +12452,15 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.7",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12067,26 +12470,31 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.6",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.6",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12759,14 +13167,74 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typed-array-length": {
-      "version": "1.0.4",
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "is-typed-array": "^1.1.9"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+      "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12893,7 +13361,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -12902,15 +13372,18 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -13498,16 +13971,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.9",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-webpack-plugin": "^4.2.0",
     "html-loader": "^4.2.0",
     "html-webpack-plugin": "^5.5.0",
     "prettier": "^2.4.1",

--- a/react/src/dashboard/components/elements/pdf-preview/PdfPreview.tsx
+++ b/react/src/dashboard/components/elements/pdf-preview/PdfPreview.tsx
@@ -12,7 +12,13 @@ export default function PdfPreview({ rawPdfFile, className = '' }: { rawPdfFile?
             let numPages = null;
 
             loadingTask.promise.then(
-                function (pdf: { numPages: number; getPage: (arg0: number) => Promise<any> }) {
+                function (pdf: {
+                    numPages: number;
+                    getPage: (arg0: number) => Promise<{
+                        getViewport: ({ scale }) => { height: number; width: number };
+                        render: ({ canvasContext, viewport }) => { promise: Promise<() => void> };
+                    }>;
+                }): void {
                     // Fetch the first page
                     numPages = pdf.numPages;
 

--- a/react/src/dashboard/components/pages/csv_validations/CsvValidations.tsx
+++ b/react/src/dashboard/components/pages/csv_validations/CsvValidations.tsx
@@ -74,7 +74,9 @@ export default function CsvValidations() {
 
             {funds?.length == 0 && (
                 <EmptyCard
-                    description={'U bent geen beoordelaar voor een fonds dat actief is om aanvragers aan toe te voegen.'}
+                    description={
+                        'U bent geen beoordelaar voor een fonds dat actief is om aanvragers aan toe te voegen.'
+                    }
                 />
             )}
         </Fragment>

--- a/react/src/dashboard/components/pages/implementations-cms-page/elements/ImplementationsCmsPageForm.tsx
+++ b/react/src/dashboard/components/pages/implementations-cms-page/elements/ImplementationsCmsPageForm.tsx
@@ -260,8 +260,8 @@ export default function ImplementationsCmsPageForm({
                                                             De interne privacyverklaring pagina wordt gehost op ons
                                                             webshopdomein. Hieronder kunt u de inhoud van de pagina
                                                             aanpassen. U kunt er ook voor kiezen om een externe
-                                                            privacyverklaring te gebruiken en de doorverwijzingslink
-                                                            op te geven.
+                                                            privacyverklaring te gebruiken en de doorverwijzingslink op
+                                                            te geven.
                                                         </div>
                                                     </div>
                                                 </div>

--- a/react/src/dashboard/hooks/useCustomInputValidationMessage.tsx
+++ b/react/src/dashboard/hooks/useCustomInputValidationMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 
 export type InputValidationTexts = {
     patternMismatch?: string;

--- a/react/src/index-dashboard.js
+++ b/react/src/index-dashboard.js
@@ -1,8 +1,11 @@
 import ReactDOM from 'react-dom/client';
 import Dashboard from './dashboard/Dashboard';
 
+// eslint-disable-next-line no-undef
 require(`../assets/forus-platform/scss/general/vars.scss`);
+// eslint-disable-next-line no-undef
 require(`../assets/forus-platform/scss/general/style-dashboard-${env_data.client_skin}.scss`);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+// eslint-disable-next-line no-undef
 root.render(<Dashboard envData={env_data} />);

--- a/react/src/index-webshop.js
+++ b/react/src/index-webshop.js
@@ -1,10 +1,15 @@
 import ReactDOM from 'react-dom/client';
 import Webshop from './webshop/Webshop';
 
+// eslint-disable-next-line no-undef
 require(`../assets/forus-webshop/scss/style-webshop-general-vars.scss`);
+// eslint-disable-next-line no-undef
 require(`../assets/forus-webshop/scss/style-webshop-${env_data.client_skin}-vars.scss`);
+// eslint-disable-next-line no-undef
 require(`../assets/forus-webshop/scss/webshop.scss`);
+// eslint-disable-next-line no-undef
 require(`../assets/forus-webshop/scss/style-webshop-${env_data.client_skin}.scss`);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+// eslint-disable-next-line no-undef
 root.render(<Webshop envData={env_data} />);

--- a/react/src/index-website.js
+++ b/react/src/index-website.js
@@ -1,8 +1,11 @@
 import ReactDOM from 'react-dom/client';
 import Website from './website/Website';
 
+// eslint-disable-next-line no-undef
 require(`../assets/forus-website/scss/website-vars.scss`);
+// eslint-disable-next-line no-undef
 require(`../assets/forus-website/scss/website.scss`);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+// eslint-disable-next-line no-undef
 root.render(<Website envData={env_data} />);

--- a/react/src/webshop/components/modals/ModalOpenInMe.tsx
+++ b/react/src/webshop/components/modals/ModalOpenInMe.tsx
@@ -12,7 +12,7 @@ import IconMeLogo from '../../../../assets/forus-webshop/resources/_webshop-comm
 import ModalAuthPincode from './ModalAuthPincode';
 import useOpenModal from '../../../dashboard/hooks/useOpenModal';
 import TranslateHtml from '../../../dashboard/components/elements/translate-html/TranslateHtml';
-import {clickOnKeyEnter} from "../../../dashboard/helpers/wcag";
+import { clickOnKeyEnter } from '../../../dashboard/helpers/wcag';
 
 export default function ModalOpenInMe({ modal }: { modal: ModalState }) {
     const translate = useTranslate();

--- a/react/src/webshop/components/modals/modal-photo-cropper/ModalPhotoCropper.tsx
+++ b/react/src/webshop/components/modals/modal-photo-cropper/ModalPhotoCropper.tsx
@@ -171,9 +171,14 @@ export default function ModalPhotoCropper({
         (rawPdfFile): Promise<Blob> => {
             return new Promise((resolve) => {
                 new Response(rawPdfFile).arrayBuffer().then((data) => {
-                    window['pdfjsDist']
-                        .getDocument({ data })
-                        .promise.then((pdf: { numPages: number; getPage: (arg0: number) => Promise<any> }) => {
+                    window['pdfjsDist'].getDocument({ data }).promise.then(
+                        (pdf: {
+                            numPages: number;
+                            getPage: (arg0: number) => Promise<{
+                                getViewport: ({ scale }) => { height: number; width: number };
+                                render: ({ canvasContext, viewport }) => { promise: Promise<() => void> };
+                            }>;
+                        }) => {
                             pdf.getPage(1).then((page) => {
                                 const viewport = page.getViewport({ scale: 1.5 });
                                 const canvas = document.createElement('canvas');
@@ -186,7 +191,9 @@ export default function ModalPhotoCropper({
                                     convertPdfCanvasToPreview(canvas).toBlob((blob) => resolve(blob), 'image/jpeg');
                                 });
                             });
-                        }, console.error);
+                        },
+                        console.error,
+                    );
                 });
             });
         },

--- a/react/src/webshop/components/pages/reimbursements-edit/ReimbursementsEdit.tsx
+++ b/react/src/webshop/components/pages/reimbursements-edit/ReimbursementsEdit.tsx
@@ -415,7 +415,9 @@ export default function ReimbursementsEdit() {
                                                         <div className="flex-inline flex-center flex-vertical">
                                                             <Tooltip
                                                                 className={'text-left'}
-                                                                text={'IBAN-nummer moet het formaat NL89BANK0123456789 hebben.'}
+                                                                text={
+                                                                    'IBAN-nummer moet het formaat NL89BANK0123456789 hebben.'
+                                                                }
                                                             />
                                                         </div>
                                                     </div>

--- a/react/src/webshop/i18n/en/components/buttons.js
+++ b/react/src/webshop/i18n/en/components/buttons.js
@@ -1,6 +1,5 @@
-module.exports = {
+export default {
     show_more: 'Show more',
-    send: 'Send',
     validate: 'Validate',
     add: 'Add',
     cancel: 'Cancel',

--- a/react/src/webshop/i18n/en/directives/app-footer.js
+++ b/react/src/webshop/i18n/en/directives/app-footer.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     links: {
         privacy: 'Privacy statement',
         accessibility: 'Accessibility statement',

--- a/react/src/webshop/i18n/en/directives/block-products.js
+++ b/react/src/webshop/i18n/en/directives/block-products.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'Offers',
     },

--- a/react/src/webshop/i18n/en/directives/block-providers.js
+++ b/react/src/webshop/i18n/en/directives/block-providers.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     empty: {
         title: 'No search result',
         subtitle: "Unfortunately! We couldn't find any offers for your search",

--- a/react/src/webshop/i18n/en/directives/contact.js
+++ b/react/src/webshop/i18n/en/directives/contact.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'contact',
         subtitle: 'CONTACT INFORMATION',

--- a/react/src/webshop/i18n/en/directives/empty-block.js
+++ b/react/src/webshop/i18n/en/directives/empty-block.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
     guide: 'Use an activationcode',
 };

--- a/react/src/webshop/i18n/en/directives/fund-criterion.js
+++ b/react/src/webshop/i18n/en/directives/fund-criterion.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // CRITERIA FOR FUNDS = fund-criterion.pug
     labels: {
         general: {

--- a/react/src/webshop/i18n/en/directives/google-map.js
+++ b/react/src/webshop/i18n/en/directives/google-map.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // GOOGLE MAPS = google-map.pug
     cancel: 'Cancel',
 };

--- a/react/src/webshop/i18n/en/directives/profile-menu.js
+++ b/react/src/webshop/i18n/en/directives/profile-menu.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'Your personal QR-code',
         subtitle: 'Have a validator scan your personal QR-code.',

--- a/react/src/webshop/i18n/en/directives/reservation-card.js
+++ b/react/src/webshop/i18n/en/directives/reservation-card.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     labels: {
         code: 'Reservation code:',
         cancel: 'Cancel reservation',

--- a/react/src/webshop/i18n/en/directives/top-navbar-search.js
+++ b/react/src/webshop/i18n/en/directives/top-navbar-search.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     result: {
         all_label: 'All results',
         providers_label: 'Providers',

--- a/react/src/webshop/i18n/en/layout/navbar.js
+++ b/react/src/webshop/i18n/en/layout/navbar.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     items: {
         funds: 'FUNDS',
         products: 'OFFERS',

--- a/react/src/webshop/i18n/en/modals/modal-auth.js
+++ b/react/src/webshop/i18n/en/modals/modal-auth.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // AUTHENTICATION POPUP = popup-auth.pug
     header: {
         berkelland: {
@@ -20,26 +20,6 @@ module.exports = {
             title: 'Log in to the Kerstpakket',
             subtitle:
                 '<span>Scan the QR-code with the</span> <strong><u>Me-app</u></strong><span> or log in with your e-mailaddress</span>',
-        },
-        berkelland: {
-            title: 'Inloggen op de Meedoenapplicatie',
-            subtitle:
-                '<span>Scan de QR-code met de</span> <strong><u>Me-app</u></strong><span> of log in met uw e-mailadres</span>',
-        },
-        oostgelre: {
-            title: 'Inloggen op de Meedoenapplicatie',
-            subtitle:
-                '<span>Scan de QR-code met de</span> <strong><u>Me-app</u></strong><span> of log in met uw e-mailadres</span>',
-        },
-        winterswijk: {
-            title: 'Inloggen op de Meedoenapplicatie',
-            subtitle:
-                '<span>Scan de QR-code met de</span> <strong><u>Me-app</u></strong><span> of log in met uw e-mailadres</span>',
-        },
-        kerstpakket: {
-            title: 'Inloggen op het Kerstpakket',
-            subtitle:
-                '<span>Scan de QR-code met de</span> <strong><u>Me-app</u></strong><span> of log in met uw e-mailadres</span>',
         },
         zuidhorn: {
             title: 'Log in to the Kindpakket',
@@ -87,15 +67,6 @@ module.exports = {
         },
         winterswijk: {
             mail: 'Please create a profile before you continue with the activation.',
-        },
-        berkelland: {
-            mail: 'Maak een account aan voordat u verder kan met de activatie.',
-        },
-        oostgelre: {
-            mail: 'Maak een account aan voordat u verder kan met de activatie.',
-        },
-        winterswijk: {
-            mail: 'Maak een account aan voordat u verder kan met de activatie.',
         },
         timelimit: 'You will be logged out automatically after 15 minutes of inactivity.',
         warning: "Close this window and click 'Login' if you have already used the activation code.",

--- a/react/src/webshop/i18n/en/modals/modal-offices.js
+++ b/react/src/webshop/i18n/en/modals/modal-offices.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'We have found {{ count }} providers',
         subtitle: 'Select to see more information',

--- a/react/src/webshop/i18n/en/modals/modal-open-in-me.js
+++ b/react/src/webshop/i18n/en/modals/modal-open-in-me.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     sms: {
         title: 'Download <i>Me</i> on your smartphone.',
         description: 'Enter your phone number to receive a downloadlink.',

--- a/react/src/webshop/i18n/en/modals/modal.js
+++ b/react/src/webshop/i18n/en/modals/modal.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     buttons: {
         cancel: 'Cancel',
         confirm: 'Confirm',

--- a/react/src/webshop/i18n/en/pages/error-page.js
+++ b/react/src/webshop/i18n/en/pages/error-page.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // error-page.pug
     404: {
         title: 'Page not found',

--- a/react/src/webshop/i18n/en/pages/fund-request.js
+++ b/react/src/webshop/i18n/en/pages/fund-request.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VALIDATION REQUEST FOR FUNDS = fund_request.pug
     sign_up: {
         block_title: '{{ fund_name }} aanvragen',

--- a/react/src/webshop/i18n/en/pages/fund.js
+++ b/react/src/webshop/i18n/en/pages/fund.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // APPLY FOR FUNDS = fund-apply.pug
     header: {
         title: 'Apply for {{fund_name}}',

--- a/react/src/webshop/i18n/en/pages/funds.js
+++ b/react/src/webshop/i18n/en/pages/funds.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // FUNDS = funds.pug
     header: {
         title: 'Funds',

--- a/react/src/webshop/i18n/en/pages/home.js
+++ b/react/src/webshop/i18n/en/pages/home.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // HOME = home.pug
     header: {
         title: '{{fund}} ',

--- a/react/src/webshop/i18n/en/pages/me-index.js
+++ b/react/src/webshop/i18n/en/pages/me-index.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     navbar: {
         municipality: 'MUNICIPALITY',
         provider: 'PROVIDER',

--- a/react/src/webshop/i18n/en/pages/notification-preferences.js
+++ b/react/src/webshop/i18n/en/pages/notification-preferences.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     title_preferences: 'Email preferences',
     subscribe_desc:
         'You are currently unsubscribed from all notifications with this e-mail address "{{email}}". If you want to receive notifications, you can set this per notification below.',

--- a/react/src/webshop/i18n/en/pages/product.js
+++ b/react/src/webshop/i18n/en/pages/product.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // PRODUCT = product.pug
     labels: {
         fund: 'Funds',

--- a/react/src/webshop/i18n/en/pages/record-validations.js
+++ b/react/src/webshop/i18n/en/pages/record-validations.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VALIDATIONS OF THE RECORDS = record-validations.pug
     header: {
         title: 'My records',

--- a/react/src/webshop/i18n/en/pages/records-create.js
+++ b/react/src/webshop/i18n/en/pages/records-create.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // CREATE A RECORD  = record.create.pug
     header: {
         title: 'Create a record',

--- a/react/src/webshop/i18n/en/pages/records-validate.js
+++ b/react/src/webshop/i18n/en/pages/records-validate.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VALIDATE A RECORD = record-validate.pug
     header: {
         title: 'My records',

--- a/react/src/webshop/i18n/en/pages/records.js
+++ b/react/src/webshop/i18n/en/pages/records.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // RECORDS = records.pug
     header: {
         title: 'Records',

--- a/react/src/webshop/i18n/en/pages/reimbursements.js
+++ b/react/src/webshop/i18n/en/pages/reimbursements.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // reimbursements = reimbursements.pug
     header: {
         title: 'My reimbursements',

--- a/react/src/webshop/i18n/en/pages/reservations.js
+++ b/react/src/webshop/i18n/en/pages/reservations.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // reservations = reservations.pug
     header: {
         title: 'My reservations',

--- a/react/src/webshop/i18n/en/pages/voucher.js
+++ b/react/src/webshop/i18n/en/pages/voucher.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VOUCHER = voucher.pug
     header: {
         title: 'Your voucher',

--- a/react/src/webshop/i18n/en/pages/vouchers.js
+++ b/react/src/webshop/i18n/en/pages/vouchers.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VOUCHERs = vouchers.pug
     header: {
         title: 'My vouchers',

--- a/react/src/webshop/i18n/i18n-en-values.js
+++ b/react/src/webshop/i18n/i18n-en-values.js
@@ -1,5 +1,5 @@
 // No nested objects allowed
-module.exports = {
+export default {
     general: {},
     zuidhorn: {},
 };

--- a/react/src/webshop/i18n/i18n-en.js
+++ b/react/src/webshop/i18n/i18n-en.js
@@ -1,4 +1,40 @@
-module.exports = {
+import fund from './en/pages/fund';
+
+import fund_request from './en/pages/fund-request';
+import funds from './en/pages/funds';
+import home from './en/pages/home';
+import meapp_index from './en/pages/me-index';
+import product from './en/pages/product';
+import records_validations from './en/pages/record-validations';
+import records_create from './en/pages/records-create';
+import records_validate from './en/pages/records-validate';
+import records from './en/pages/records';
+import voucher from './en/pages/voucher';
+import vouchers from './en/pages/vouchers';
+import reservations from './en/pages/reservations';
+import reimbursements from './en/pages/reimbursements';
+import notification_preferences from './en/pages/notification-preferences';
+import error_page from './en/pages/error-page';
+
+import buttons from './en/components/buttons';
+import topnavbar from './en/layout/navbar';
+
+import popup_auth from './en/modals/modal-auth';
+import popup_offices from './en/modals/modal-offices';
+import open_in_me from './en/modals/modal-open-in-me';
+import modal from './en/modals/modal';
+
+import app_footer from './en/directives/app-footer';
+import block_products from './en/directives/block-products';
+import block_providers from './en/directives/block-providers';
+import empty_block from './en/directives/empty-block';
+import fund_criterion from './en/directives/fund-criterion';
+import maps from './en/directives/google-map';
+import profile_menu from './en/directives/profile-menu';
+import top_navbar_search from './en/directives/top-navbar-search';
+import reservation from './nl/directives/reservation-card';
+
+export default {
     test: '{{name}} {{foo}}',
     page_title: 'Webshop',
     page_state_titles: {
@@ -40,43 +76,43 @@ module.exports = {
     },
 
     // COMPONENTS
-    buttons: require('./en/components/buttons'),
+    buttons: buttons,
 
     // LAYOUT
-    topnavbar: require('./en/layout/navbar'),
+    topnavbar: topnavbar,
 
     // PAGES
-    fund: require('./en/pages/fund'),
-    fund_request: require('./en/pages/fund-request'),
-    funds: require('./en/pages/funds'),
-    home: require('./en/pages/home'),
-    meapp_index: require('./en/pages/me-index'),
-    product: require('./en/pages/product'),
-    records_validations: require('./en/pages/record-validations'),
-    records_create: require('./en/pages/records-create'),
-    records_validate: require('./en/pages/records-validate'),
-    records: require('./en/pages/records'),
-    voucher: require('./en/pages/voucher'),
-    vouchers: require('./en/pages/vouchers'),
-    reservations: require('./en/pages/reservations'),
-    reimbursements: require('./en/pages/reimbursements'),
-    notification_preferences: require('./en/pages/notification-preferences'),
-    error_page: require('./en/pages/error-page'),
+    fund: fund,
+    fund_request: fund_request,
+    funds: funds,
+    home: home,
+    meapp_index: meapp_index,
+    product: product,
+    records_validations: records_validations,
+    records_create: records_create,
+    records_validate: records_validate,
+    records: records,
+    voucher: voucher,
+    vouchers: vouchers,
+    reservations: reservations,
+    reimbursements: reimbursements,
+    notification_preferences: notification_preferences,
+    error_page: error_page,
 
     // MODALS
-    popup_auth: require('./en/modals/modal-auth'),
-    popup_offices: require('./en/modals/modal-offices'),
-    open_in_me: require('./en/modals/modal-open-in-me'),
-    modal: require('./en/modals/modal'),
+    popup_auth: popup_auth,
+    popup_offices: popup_offices,
+    open_in_me: open_in_me,
+    modal: modal,
 
     // DIRECTIVES
-    app_footer: require('./en/directives/app-footer'),
-    block_products: require('./en/directives/block-products'),
-    block_providers: require('./en/directives/block-providers'),
-    empty_block: require('./en/directives/empty-block'),
-    fund_criterion: require('./en/directives/fund-criterion'),
-    maps: require('./en/directives/google-map'),
-    profile_menu: require('./en/directives/profile-menu'),
-    top_navbar_search: require('./en/directives/top-navbar-search'),
-    reservation: require('./nl/directives/reservation-card'),
+    app_footer: app_footer,
+    block_products: block_products,
+    block_providers: block_providers,
+    empty_block: empty_block,
+    fund_criterion: fund_criterion,
+    maps: maps,
+    profile_menu: profile_menu,
+    top_navbar_search: top_navbar_search,
+    reservation: reservation,
 };

--- a/react/src/webshop/i18n/i18n-nl-values.js
+++ b/react/src/webshop/i18n/i18n-nl-values.js
@@ -1,5 +1,5 @@
 // No nested objects allowed
-module.exports = {
+export default {
     general: {
         name: 'General',
         fund: 'het Forus-fonds',

--- a/react/src/webshop/i18n/i18n-nl.js
+++ b/react/src/webshop/i18n/i18n-nl.js
@@ -1,4 +1,62 @@
-module.exports = {
+import buttons from './nl/components/buttons';
+import topnavbar from './nl/layout/navbar';
+
+import signup_options from './nl/pages/signup-options';
+import fund from './nl/pages/fund';
+import fund_activate from './nl/pages/fund-activate';
+import fund_request from './nl/pages/fund-request';
+import fund_requests from './nl/pages/fund-requests';
+import fund_request_clarification from './nl/pages/fund-request-clarification';
+import funds from './nl/pages/funds';
+import home from './nl/pages/home';
+import signup from './nl/pages/signup';
+import meapp_index from './nl/pages/me-index';
+import product from './nl/pages/product';
+import records_validations from './nl/pages/record-validations';
+import records_create from './nl/pages/records-create';
+import records_validate from './nl/pages/records-validate';
+import records from './nl/pages/records';
+import voucher from './nl/pages/voucher';
+import vouchers from './nl/pages/vouchers';
+import reservations from './nl/pages/reservations';
+import reimbursements from './nl/pages/reimbursements';
+import notification_preferences from './nl/pages/notification-preferences';
+import email_preferences from './nl/pages/email-preferences';
+import voucher_printable from './nl/pages/voucher-printable';
+import accessibility from './nl/pages/accessibility';
+import error_page from './nl/pages/error-page';
+import privacy from './nl/pages/privacy';
+import error from './nl/pages/error';
+
+import popup_auth from './nl/modals/modal-auth';
+import logout from './nl/modals/modal-logout';
+import popup_offices from './nl/modals/modal-offices';
+import open_in_me from './nl/modals/modal-open-in-me';
+import physical_card from './nl/modals/modal-physical_card';
+import expired_identity from './nl/modals/modal-expired-identity-proxy';
+import pdf_preview from './nl/modals/modal-pdf-preview';
+import image_preview from './nl/modals/modal-image-preview';
+import modal from './nl/modals/modal';
+import modal_product_reserve from './nl/modals/modal-product-reserve';
+import modal_product_reserve_notes from './nl/modals/modal-product-reserve-notes';
+import modal_product_reserve_extra_payment from './nl/modals/modal-product-reserve-extra-payment';
+import modal_product_reserve_cancel from './nl/modals/modal-product-reserve-cancel';
+import modal_2fa_setup from './nl/modals/modal-2fa-setup';
+
+import app_footer from './nl/directives/app-footer';
+import block_products from './nl/directives/block-products';
+import block_funds from './nl/directives/block-funds';
+import block_notifications from './nl/directives/block-notifications';
+import block_providers from './nl/directives/block-providers';
+import empty_block from './nl/directives/empty-block';
+import fund_criterion from './nl/directives/fund-criterion';
+import maps from './nl/directives/google-map';
+import profile_menu from './nl/directives/profile-menu';
+import top_navbar_search from './nl/directives/top-navbar-search';
+import reservation from './nl/directives/reservation-card';
+import paginator from './nl/directives/paginator';
+
+export default {
     test: '{{name}} {{foo}}',
     page_title: 'Forus platform',
     page_state_loading_titles: {
@@ -111,66 +169,66 @@ module.exports = {
     },
 
     // COMPONENTS
-    buttons: require('./nl/components/buttons'),
+    buttons: buttons,
 
     // LAYOUT
-    topnavbar: require('./nl/layout/navbar'),
+    topnavbar: topnavbar,
 
     // PAGES
-    signup_options: require('./nl/pages/signup-options'),
-    fund: require('./nl/pages/fund'),
-    fund_activate: require('./nl/pages/fund-activate'),
-    fund_request: require('./nl/pages/fund-request'),
-    fund_requests: require('./nl/pages/fund-requests'),
-    fund_request_clarification: require('./nl/pages/fund-request-clarification'),
-    funds: require('./nl/pages/funds'),
-    home: require('./nl/pages/home'),
-    signup: require('./nl/pages/signup'),
-    meapp_index: require('./nl/pages/me-index'),
-    product: require('./nl/pages/product'),
-    records_validations: require('./nl/pages/record-validations'),
-    records_create: require('./nl/pages/records-create'),
-    records_validate: require('./nl/pages/records-validate'),
-    records: require('./nl/pages/records'),
-    voucher: require('./nl/pages/voucher'),
-    vouchers: require('./nl/pages/vouchers'),
-    reservations: require('./nl/pages/reservations'),
-    reimbursements: require('./nl/pages/reimbursements'),
-    notification_preferences: require('./nl/pages/notification-preferences'),
-    email_preferences: require('./nl/pages/email-preferences'),
-    voucher_printable: require('./nl/pages/voucher-printable'),
-    accessibility: require('./nl/pages/accessibility'),
-    error_page: require('./nl/pages/error-page'),
-    privacy: require('./nl/pages/privacy'),
-    error: require('./nl/pages/error'),
+    signup_options: signup_options,
+    fund: fund,
+    fund_activate: fund_activate,
+    fund_request: fund_request,
+    fund_requests: fund_requests,
+    fund_request_clarification: fund_request_clarification,
+    funds: funds,
+    home: home,
+    signup: signup,
+    meapp_index: meapp_index,
+    product: product,
+    records_validations: records_validations,
+    records_create: records_create,
+    records_validate: records_validate,
+    records: records,
+    voucher: voucher,
+    vouchers: vouchers,
+    reservations: reservations,
+    reimbursements: reimbursements,
+    notification_preferences: notification_preferences,
+    email_preferences: email_preferences,
+    voucher_printable: voucher_printable,
+    accessibility: accessibility,
+    error_page: error_page,
+    privacy: privacy,
+    error: error,
 
     // MODALS
-    popup_auth: require('./nl/modals/modal-auth'),
-    logout: require('./nl/modals/modal-logout'),
-    popup_offices: require('./nl/modals/modal-offices'),
-    open_in_me: require('./nl/modals/modal-open-in-me'),
-    physical_card: require('./nl/modals/modal-physical_card'),
-    expired_identity: require('./nl/modals/modal-expired-identity-proxy'),
-    pdf_preview: require('./nl/modals/modal-pdf-preview'),
-    image_preview: require('./nl/modals/modal-image-preview'),
-    modal: require('./nl/modals/modal'),
-    modal_product_reserve: require('./nl/modals/modal-product-reserve'),
-    modal_product_reserve_notes: require('./nl/modals/modal-product-reserve-notes'),
-    modal_product_reserve_extra_payment: require('./nl/modals/modal-product-reserve-extra-payment'),
-    modal_product_reserve_cancel: require('./nl/modals/modal-product-reserve-cancel'),
-    modal_2fa_setup: require('./nl/modals/modal-2fa-setup'),
+    popup_auth: popup_auth,
+    logout: logout,
+    popup_offices: popup_offices,
+    open_in_me: open_in_me,
+    physical_card: physical_card,
+    expired_identity: expired_identity,
+    pdf_preview: pdf_preview,
+    image_preview: image_preview,
+    modal: modal,
+    modal_product_reserve: modal_product_reserve,
+    modal_product_reserve_notes: modal_product_reserve_notes,
+    modal_product_reserve_extra_payment: modal_product_reserve_extra_payment,
+    modal_product_reserve_cancel: modal_product_reserve_cancel,
+    modal_2fa_setup: modal_2fa_setup,
 
     // DIRECTIVES
-    app_footer: require('./nl/directives/app-footer'),
-    block_products: require('./nl/directives/block-products'),
-    block_funds: require('./nl/directives/block-funds'),
-    block_notifications: require('./nl/directives/block-notifications'),
-    block_providers: require('./nl/directives/block-providers'),
-    empty_block: require('./nl/directives/empty-block'),
-    fund_criterion: require('./nl/directives/fund-criterion'),
-    maps: require('./nl/directives/google-map'),
-    profile_menu: require('./nl/directives/profile-menu'),
-    top_navbar_search: require('./nl/directives/top-navbar-search'),
-    reservation: require('./nl/directives/reservation-card'),
-    paginator: require('./nl/directives/paginator'),
+    app_footer: app_footer,
+    block_products: block_products,
+    block_funds: block_funds,
+    block_notifications: block_notifications,
+    block_providers: block_providers,
+    empty_block: empty_block,
+    fund_criterion: fund_criterion,
+    maps: maps,
+    profile_menu: profile_menu,
+    top_navbar_search: top_navbar_search,
+    reservation: reservation,
+    paginator: paginator,
 };

--- a/react/src/webshop/i18n/nl/components/buttons.js
+++ b/react/src/webshop/i18n/nl/components/buttons.js
@@ -1,6 +1,5 @@
-module.exports = {
+export default {
     show_more: 'Bekijk meer',
-    send: 'Verzenden',
     validate: 'Goedkeuren',
     add: 'Toevoegen',
     cancel: 'Annuleren',

--- a/react/src/webshop/i18n/nl/directives/app-footer.js
+++ b/react/src/webshop/i18n/nl/directives/app-footer.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     links: {
         privacy: 'Privacyverklaring',
         accessibility: 'Toegankelijkheidsverklaring',

--- a/react/src/webshop/i18n/nl/directives/block-funds.js
+++ b/react/src/webshop/i18n/nl/directives/block-funds.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     labels: {
         title: 'Resultaten',
         subtitle: 'Geen resultaten',

--- a/react/src/webshop/i18n/nl/directives/block-notifications.js
+++ b/react/src/webshop/i18n/nl/directives/block-notifications.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     labels: {
         title: 'Notificaties',
         subtitle:

--- a/react/src/webshop/i18n/nl/directives/block-products.js
+++ b/react/src/webshop/i18n/nl/directives/block-products.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title_budget: 'Aanbod',
         title_subsidies: 'Aanbod',

--- a/react/src/webshop/i18n/nl/directives/block-providers.js
+++ b/react/src/webshop/i18n/nl/directives/block-providers.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     empty: {
         title: 'Geen zoekresultaat',
         subtitle: 'Helaas! Wij vonden geen aanbieders voor uw zoekopdracht',

--- a/react/src/webshop/i18n/nl/directives/empty-block.js
+++ b/react/src/webshop/i18n/nl/directives/empty-block.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
     guide: 'Gebruik de activatie code',
 };

--- a/react/src/webshop/i18n/nl/directives/fund-criterion.js
+++ b/react/src/webshop/i18n/nl/directives/fund-criterion.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // CRITERIA FOR FUNDS = fund-criterion.pug
     labels: {
         general: {

--- a/react/src/webshop/i18n/nl/directives/google-map.js
+++ b/react/src/webshop/i18n/nl/directives/google-map.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // GOOGLE MAPS = google-map.pug
     cancel: 'Annuleren',
     no_data: 'Geen data',

--- a/react/src/webshop/i18n/nl/directives/paginator.js
+++ b/react/src/webshop/i18n/nl/directives/paginator.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     buttons: {
         first: 'Eerste',
         last: 'Laatste',

--- a/react/src/webshop/i18n/nl/directives/profile-menu.js
+++ b/react/src/webshop/i18n/nl/directives/profile-menu.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'Uw persoonlijke QR-code',
         subtitle: 'Laat uw persoonlijke QR-code scannen door een beoordelaar.',

--- a/react/src/webshop/i18n/nl/directives/reservation-card.js
+++ b/react/src/webshop/i18n/nl/directives/reservation-card.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     labels: {
         code: 'Reserveringsnummer:',
         cancel: 'Annuleren',

--- a/react/src/webshop/i18n/nl/directives/top-navbar-search.js
+++ b/react/src/webshop/i18n/nl/directives/top-navbar-search.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     placeholders: {
         search_informal: 'Waar ben je naar op zoek?',
         search_formal: 'Waar bent u naar op zoek?',

--- a/react/src/webshop/i18n/nl/layout/navbar.js
+++ b/react/src/webshop/i18n/nl/layout/navbar.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     items: {
         home: 'Home',
         funds: 'Activeren',
@@ -18,6 +18,7 @@ module.exports = {
         },
         groningen: {
             funds: 'Aanvragen',
+            explanation: 'Hoe werkt het?',
         },
         waalwijk: {
             funds: 'Aanvragen',
@@ -49,9 +50,6 @@ module.exports = {
         },
         noordoostpolder: {
             funds: 'Regelingen',
-        },
-        groningen: {
-            explanation: 'Hoe werkt het?',
         },
     },
     buttons: {
@@ -148,7 +146,7 @@ module.exports = {
                     funds: 'Activeren',
                 },
                 noordoostpolder: {
-                    funds: 'Activeren',
+                    funds: 'Regelingen',
                 },
                 vergoedingen: {
                     funds: 'Vergoedingen',
@@ -157,9 +155,6 @@ module.exports = {
                     funds: 'Regelingen',
                 },
                 ede: {
-                    funds: 'Regelingen',
-                },
-                noordoostpolder: {
                     funds: 'Regelingen',
                 },
             },

--- a/react/src/webshop/i18n/nl/modals/modal-2fa-setup.js
+++ b/react/src/webshop/i18n/nl/modals/modal-2fa-setup.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     errors: {
         code_sent:
             'Er is iets fout gegaan tijdens het versturen van de SMS. Is het juiste telefoonnummer ingevuld? Probeer het anders nog een keer.',

--- a/react/src/webshop/i18n/nl/modals/modal-auth.js
+++ b/react/src/webshop/i18n/nl/modals/modal-auth.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // AUTHENTICATION POPUP = popup-auth.pug
     header: {
         title: 'E-mail verstuurd',

--- a/react/src/webshop/i18n/nl/modals/modal-expired-identity-proxy.js
+++ b/react/src/webshop/i18n/nl/modals/modal-expired-identity-proxy.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'De link is verlopen',
     },

--- a/react/src/webshop/i18n/nl/modals/modal-image-preview.js
+++ b/react/src/webshop/i18n/nl/modals/modal-image-preview.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'Afbeelding-voorbeeld',
     },

--- a/react/src/webshop/i18n/nl/modals/modal-logout.js
+++ b/react/src/webshop/i18n/nl/modals/modal-logout.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     title_formal: 'Weet u zeker dat u wilt uitloggen?',
     title_informal: 'Weet je zeker dat je wilt uitloggen?',
 };

--- a/react/src/webshop/i18n/nl/modals/modal-offices.js
+++ b/react/src/webshop/i18n/nl/modals/modal-offices.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'We hebben {{ count }} aanbieders gevonden',
         subtitle: 'Selecteer een om meer informatie te zien',

--- a/react/src/webshop/i18n/nl/modals/modal-open-in-me.js
+++ b/react/src/webshop/i18n/nl/modals/modal-open-in-me.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'Open de in Me app',
     },

--- a/react/src/webshop/i18n/nl/modals/modal-pdf-preview.js
+++ b/react/src/webshop/i18n/nl/modals/modal-pdf-preview.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'PDF-voorbeeld',
     },

--- a/react/src/webshop/i18n/nl/modals/modal-physical_card.js
+++ b/react/src/webshop/i18n/nl/modals/modal-physical_card.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     modal_section: {
         type_selection: {
             title: 'Gebruik mijn QR-code',

--- a/react/src/webshop/i18n/nl/modals/modal-product-reserve-cancel.js
+++ b/react/src/webshop/i18n/nl/modals/modal-product-reserve-cancel.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // PRODUCT RESERVE CANCEL POPUP = popup-product-reserve-cancel.pug
     header_not_cancelable: {
         title: 'Neem contact op met {{organizationName}}',

--- a/react/src/webshop/i18n/nl/modals/modal-product-reserve-extra-payment.js
+++ b/react/src/webshop/i18n/nl/modals/modal-product-reserve-extra-payment.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'Kies een bank',
         subtitle: 'Bijbetalingen worden gedaan via IDeal.',

--- a/react/src/webshop/i18n/nl/modals/modal-product-reserve-notes.js
+++ b/react/src/webshop/i18n/nl/modals/modal-product-reserve-notes.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     fill_notes: {
         header: {
             title: 'Vul uw gegevens in',

--- a/react/src/webshop/i18n/nl/modals/modal-product-reserve.js
+++ b/react/src/webshop/i18n/nl/modals/modal-product-reserve.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // PRODUCT RESERVE POPUP = popup-product-reserve.pug
     header: {
         title: 'Maak een reservering',

--- a/react/src/webshop/i18n/nl/modals/modal.js
+++ b/react/src/webshop/i18n/nl/modals/modal.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     buttons: {
         cancel: 'Annuleren',
         confirm: 'Bevestigen',

--- a/react/src/webshop/i18n/nl/pages/accessibility.js
+++ b/react/src/webshop/i18n/nl/pages/accessibility.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     westerkwartier: {
         employee: 'Ard van der Tuuk, Burgemeester',
     },

--- a/react/src/webshop/i18n/nl/pages/email-preferences.js
+++ b/react/src/webshop/i18n/nl/pages/email-preferences.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     title_preferences: 'E-mail instellingen',
     title_email_preferences: 'E-mail instellingen',
 

--- a/react/src/webshop/i18n/nl/pages/error-page.js
+++ b/react/src/webshop/i18n/nl/pages/error-page.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // error-page.pug
     404: {
         title: 'Pagina niet gevonden',

--- a/react/src/webshop/i18n/nl/pages/error.js
+++ b/react/src/webshop/i18n/nl/pages/error.js
@@ -82,7 +82,7 @@ const messages = {
     digid_010c: digiDefaultMessage, // 'DigiD - temporarily unavailable',
 };
 
-module.exports = {
+export default {
     ...{ titles, messages },
     ...{
         home_button: 'Ga terug naar de startpagina',

--- a/react/src/webshop/i18n/nl/pages/fund-activate.js
+++ b/react/src/webshop/i18n/nl/pages/fund-activate.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // PAGE = fund-activate.pug
     header: {
         title: 'Bevestig uw inkomen',

--- a/react/src/webshop/i18n/nl/pages/fund-request-clarification.js
+++ b/react/src/webshop/i18n/nl/pages/fund-request-clarification.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // FUND REQUEST VALIDATION CLARIFICATION = fund-request-clarification.pug
     block_title: '{{ fund_name }} aanvulverzoek',
     labels: {

--- a/react/src/webshop/i18n/nl/pages/fund-request.js
+++ b/react/src/webshop/i18n/nl/pages/fund-request.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VALIDATION REQUEST FOR FUNDS = fund_request.pug
     approved_request_exists: 'Er bestaat al een goedgekeurde aanvraag. Neem contact op met de beheerder.',
     fund_not_active: 'Het fonds waar u voor zich probeert aan te melden is niet actief.',

--- a/react/src/webshop/i18n/nl/pages/fund-requests.js
+++ b/react/src/webshop/i18n/nl/pages/fund-requests.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'Aanvragen',
     },

--- a/react/src/webshop/i18n/nl/pages/fund.js
+++ b/react/src/webshop/i18n/nl/pages/fund.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // APPLY FOR FUNDS = fund-apply.pug
     header: {
         title: '{{fund_name}} aanmelden',

--- a/react/src/webshop/i18n/nl/pages/funds.js
+++ b/react/src/webshop/i18n/nl/pages/funds.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // FUNDS = funds.pug
     header: {
         title: 'Aanvragen',

--- a/react/src/webshop/i18n/nl/pages/home.js
+++ b/react/src/webshop/i18n/nl/pages/home.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // HOME = home.pug
     header: {
         title: '{{implementation}}',
@@ -17,9 +17,6 @@ module.exports = {
         auth_button: 'Download Me',
         signup_cta: 'Lees meer >',
         button: 'Inloggen',
-        potjeswijzer: {
-            button: 'Start aanvraag',
-        },
         westerkwartier: {
             subtitle_av:
                 'Er bestaan veel verschillende potjes binnen het Westerkwartier, vaak meer dan je denkt. Met deze website kan je potjes aanvragen, beheren en uitgeven.',
@@ -33,6 +30,7 @@ module.exports = {
                 'Er bestaan veel verschillende potjes binnen het Westerkwartier, vaak meer dan je denkt. Met deze website kan je potjes aanvragen, beheren en uitgeven.',
             cta_av: '',
             button_av: 'Start',
+            button: 'Start aanvraag',
         },
         berkelland: {
             title_multi: 'Kindregeling gemeente Berkelland',
@@ -299,10 +297,6 @@ module.exports = {
         four: "Met het tegoed betaalt u bij deelnemende aanbieders. De aanbieder scant uw code. Daarna wordt het tegoed automatisch afgeschreven. Via de lijst met deelnemende aanbieders en de pagina 'Aanbod' kunt u zien waar en waaraan u uw tegoed kunt besteden.",
         stepfive: 'Stap 5',
         five: "Klik op 'Aanbod' om het aanbod te zien. Als u klikt op 'Mijn tegoeden' ziet u hoeveel tegoed u heeft.",
-        westerkwartier: {
-            three: 'Klik daarna op ‘Aanbod’ om het aanbod op de webshop te zien. Ook kunt u uw tegoed zien. het tegoed met het tegoed vindt u terug door bovenaan op ‘Mijn tegoeden’ te klikken.',
-            four: "Bij ‘Mijn tegoeden’ staat ook een persoonlijke QR-code. Daarmee betaalt u de aanbieder waar u een aankoop wilt doen. De QR-code kunt u uitprinten, naar uzelf mailen of op uw telefoon hebben door in te loggen op de app <a href='#!/me' tartget='_blank'><u><i>Me</i></u></a>. De app <a href='#!/me' tartget='_blank'><u><i>Me</i></u></a> kunt u downloaden via de Google Playstore en de App Store.",
-        },
         noordoostpolder: {
             one: 'U heeft van de gemeente een brief ontvangen met een activatiecode voor het Meedoenpakket.',
             two: 'Klik op <u>Start</u> om uw e-mailadres en activatiecode in te vullen. Gebruik per activatiecode een ander e-mailadres.',

--- a/react/src/webshop/i18n/nl/pages/me-index.js
+++ b/react/src/webshop/i18n/nl/pages/me-index.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     navbar: {
         municipality: 'Gemeente',
         provider: 'Aanbieder',

--- a/react/src/webshop/i18n/nl/pages/notification-preferences.js
+++ b/react/src/webshop/i18n/nl/pages/notification-preferences.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     title_preferences: 'Notificatievoorkeuren',
     title_emails_turned_on: 'Inschrijven voor alle e-mails',
     title_emails_turned_of: 'Uitschrijven voor alle e-mails',

--- a/react/src/webshop/i18n/nl/pages/privacy.js
+++ b/react/src/webshop/i18n/nl/pages/privacy.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     title: 'Privacyverklaring',
 
     one: 'De volgende gegevens worden opgeslagen:',

--- a/react/src/webshop/i18n/nl/pages/product.js
+++ b/react/src/webshop/i18n/nl/pages/product.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // PRODUCT = product.pug
     headers: {
         home: 'Home',

--- a/react/src/webshop/i18n/nl/pages/record-validations.js
+++ b/react/src/webshop/i18n/nl/pages/record-validations.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VALIDATIONS OF THE RECORDS = record-validations.pug
     header: {
         title: 'Mijn persoonsgegevens',

--- a/react/src/webshop/i18n/nl/pages/records-create.js
+++ b/react/src/webshop/i18n/nl/pages/records-create.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // CREATE A RECORD  = record.create.pug
     header: {
         title: 'Persoonsgegevens aanmaken',

--- a/react/src/webshop/i18n/nl/pages/records-validate.js
+++ b/react/src/webshop/i18n/nl/pages/records-validate.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VALIDATE A RECORD = record-validate.pug
     header: {
         title: 'Mijn persoonsgegevens',

--- a/react/src/webshop/i18n/nl/pages/records.js
+++ b/react/src/webshop/i18n/nl/pages/records.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // RECORDS = records.pug
     header: {
         title: 'Persoonsgegevens',

--- a/react/src/webshop/i18n/nl/pages/reimbursements.js
+++ b/react/src/webshop/i18n/nl/pages/reimbursements.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // reimbursements = reimbursements.pug
     header: {
         title: 'Kosten terugvragen',

--- a/react/src/webshop/i18n/nl/pages/reservations.js
+++ b/react/src/webshop/i18n/nl/pages/reservations.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // reservations = reservations.pug
     header: {
         title: 'Reserveringen',

--- a/react/src/webshop/i18n/nl/pages/signup-options.js
+++ b/react/src/webshop/i18n/nl/pages/signup-options.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     header: {
         title: 'Informatie voor organisaties',
         subtitle:

--- a/react/src/webshop/i18n/nl/pages/signup.js
+++ b/react/src/webshop/i18n/nl/pages/signup.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // SIGNUP = sign-up.pug
     items: {
         title: 'Inloggen',

--- a/react/src/webshop/i18n/nl/pages/voucher-printable.js
+++ b/react/src/webshop/i18n/nl/pages/voucher-printable.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     product_voucher: {
         labels: {
             use_for: 'Gebruik dit tegoed voor:',

--- a/react/src/webshop/i18n/nl/pages/voucher.js
+++ b/react/src/webshop/i18n/nl/pages/voucher.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VOUCHER = voucher.pug
     header: {
         title: 'Uw tegoed',

--- a/react/src/webshop/i18n/nl/pages/vouchers.js
+++ b/react/src/webshop/i18n/nl/pages/vouchers.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     // VOUCHERs = vouchers.pug
     header: {
         title: 'Mijn tegoeden',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const timestamp = new Date().getTime();
 const isDevServer = process.env.WEBPACK_SERVE;
 const CopyPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const ESLintPlugin = require('eslint-webpack-plugin');
 const envData = require('./env.js');
 const { info: logInfo } = console;
 
@@ -250,6 +251,14 @@ module.exports = (env, argv) => {
             buildGzipFiles ? new CompressionPlugin({ algorithm: 'gzip', test: /\.js(\?.*)?$/i }) : null,
             new DefinePlugin({ __REACT_DEVTOOLS_GLOBAL_HOOK__: '({ isDisabled: true })' }),
             new ProvidePlugin({ React: 'react' }),
+            new ESLintPlugin({
+                extensions: ['js', 'mjs', 'jsx', 'ts', 'tsx'],
+                eslintPath: require.resolve('eslint'),
+                failOnError: true,
+                failOnWarning: true,
+                cache: true,
+                resolvePluginsRelativeTo: __dirname,
+            }),
         ].filter((plugin) => plugin),
 
         optimization: {


### PR DESCRIPTION
## Changes description & testing suggestions
Add eslint plugin to webpack builder to make the build fail if any warnings or prettier errors encountered and harden eslint rules.

![image](https://github.com/user-attachments/assets/c61432fc-24cb-4213-b268-65787b9ac139)
![image](https://github.com/user-attachments/assets/307cdb83-a510-46b5-af45-8a0132a0e23e)


<!---
Add tag if PR:
- [ ] *Needs Translations* @lexlog @irinaBerendeeva87
- [ ] *Could affect implementations custom css* @lexlog @irinaBerendeeva87
-->

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## QA checklist
- *Check regress in implementations custom css* - changes are not breaking other implementations designes
- Feature is tested in different screen sizes - desktop, mobile
- WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- Translations are done
