### PR TITLE
markdown block - convert h4 before table to caption and fix first row…

### DIFF
--- a/react/assets/forus-platform/scss/_common/blocks/block-markdown.scss
+++ b/react/assets/forus-platform/scss/_common/blocks/block-markdown.scss
@@ -83,6 +83,13 @@
         border-right: none;
         background-color: #fff;
 
+        & > caption {
+            font: 500 1.25em var(--base-font);
+            margin: 0 0 0.9em;
+            color: var(--htc);
+            text-align: left;
+        }
+
         thead {
             display: none;
         }

--- a/react/assets/forus-webshop/scss/_common/sections/blocks/block-markdown.scss
+++ b/react/assets/forus-webshop/scss/_common/sections/blocks/block-markdown.scss
@@ -37,7 +37,8 @@
         font: inherit;
     }
 
-    ul, ol {
+    ul,
+    ol {
         margin: 0 0 15px;
         padding-left: 18px;
 
@@ -84,26 +85,33 @@
         width: 100%;
         margin: 0 0 20px;
         font: inherit;
-    
+
+        & > caption {
+            font: 500 1.25em var(--hf);
+            color: var(--htc);
+            margin: 0 0 0.9em;
+            text-align: left;
+        }
+
         tr {
             text-align: left;
             font: inherit;
-    
+
             td,
             th {
                 padding: 15px 15px;
                 cursor: default;
                 border-bottom: 1px solid #d4d9dd;
                 transition: 0.3s;
-    
-                &>a {
+
+                & > a {
                     font: inherit;
                 }
-    
+
                 &:first-child {
                     padding-left: 25px;
                 }
-    
+
                 &:last-child {
                     padding-right: 25px;
                 }
@@ -120,12 +128,12 @@
                     font: inherit;
                 }
             }
-    
+
             td {
                 color: #444a4f;
                 font: inherit;
             }
-    
+
             &:last-child {
                 td {
                     border-bottom: none;
@@ -133,11 +141,10 @@
             }
         }
 
-        &>tr,
-        &>thead:last-child>tr,
-        &>tbody:last-child>tr {
+        & > tr,
+        & > thead:last-child > tr,
+        & > tbody:last-child > tr {
             &:last-child {
-
                 td,
                 th {
                     border-bottom: 0;


### PR DESCRIPTION
… td to th transform

## Changes description & testing suggestions
- Fill in markdown tables "th"
- Convert h4 header to caption, if it is placed right before table in markdown

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## QA checklist
- *Check regress in implementations custom css* - changes are not breaking other implementations designes
- Feature is tested in different screen sizes - desktop, mobile
- WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- Translations are done
