### PR TITLE
Change focus order for mobile header and menu

### DIFF
--- a/react/src/webshop/components/elements/top-navbar/TopNavbar.tsx
+++ b/react/src/webshop/components/elements/top-navbar/TopNavbar.tsx
@@ -17,6 +17,7 @@ import TopNavbarSearch from './TopNavbarSearch';
 import Announcements from '../announcements/Announcements';
 import ModalAuthPincode from '../../modals/ModalAuthPincode';
 import { clickOnKeyEnter } from '../../../../dashboard/helpers/wcag';
+import LayoutMobileMenu from '../../../layout/elements/LayoutMobileMenu';
 
 export const TopNavbar = ({ hideOnScroll = false, className = '' }: { hideOnScroll?: boolean; className?: string }) => {
     const {
@@ -404,16 +405,22 @@ export const TopNavbar = ({ hideOnScroll = false, className = '' }: { hideOnScro
             {appConfigs.announcements && <Announcements announcements={appConfigs.announcements} />}
 
             {!showSearchBox && (
-                <div className="navbar-inner wrapper">
-                    <div
-                        className={`button navbar-menu-button show-sm ${mobileMenuOpened ? 'active' : ''}`}
-                        aria-expanded={mobileMenuOpened}
-                        onClick={openMobileMenu}>
-                        <em className={`mdi ${mobileMenuOpened ? 'mdi-close' : 'mdi-menu'}`} />
-                        {mobileMenuOpened
-                            ? translate('topnavbar.items.menu.close')
-                            : translate('topnavbar.items.menu.show')}
-                    </div>
+                <div className="navbar-inner wrapper flex-horizontal-reverse">
+                    {envData.config?.flags?.genericSearch ? (
+                        <div
+                            className="button navbar-search-button show-sm"
+                            onClick={(e) => toggleSearchBox(e)}
+                            aria-expanded={showSearchBox}
+                            aria-controls={'navbar-search'}
+                            role="button"
+                            onKeyDown={clickOnKeyEnter}
+                            tabIndex={0}>
+                            <em className="mdi mdi-magnify" />
+                            {translate('topnavbar.items.search')}
+                        </div>
+                    ) : (
+                        <div className="button navbar-search-button show-sm" aria-hidden="true" />
+                    )}
 
                     <StateNavLink
                         name={'home'}
@@ -431,19 +438,18 @@ export const TopNavbar = ({ hideOnScroll = false, className = '' }: { hideOnScro
                         />
                     </StateNavLink>
 
-                    {envData.config?.flags?.genericSearch ? (
-                        <div
-                            className="button navbar-search-button show-sm"
-                            onClick={(e) => toggleSearchBox(e)}
-                            aria-expanded={showSearchBox}
-                            aria-controls={'navbar-search'}
-                            role="button">
-                            <em className="mdi mdi-magnify" />
-                            {translate('topnavbar.items.search')}
-                        </div>
-                    ) : (
-                        <div className="button navbar-search-button show-sm" aria-hidden="true" />
-                    )}
+                    <div
+                        className={`button navbar-menu-button show-sm ${mobileMenuOpened ? 'active' : ''}`}
+                        aria-expanded={mobileMenuOpened}
+                        onClick={openMobileMenu}
+                        role={'button'}
+                        onKeyDown={clickOnKeyEnter}
+                        tabIndex={0}>
+                        <em className={`mdi ${mobileMenuOpened ? 'mdi-close' : 'mdi-menu'}`} />
+                        {mobileMenuOpened
+                            ? translate('topnavbar.items.menu.close')
+                            : translate('topnavbar.items.menu.show')}
+                    </div>
                 </div>
             )}
 
@@ -568,6 +574,8 @@ export const TopNavbar = ({ hideOnScroll = false, className = '' }: { hideOnScro
                     </div>
                 </div>
             )}
+
+            <LayoutMobileMenu />
         </nav>
     );
 };

--- a/react/src/webshop/layout/Layout.tsx
+++ b/react/src/webshop/layout/Layout.tsx
@@ -10,7 +10,6 @@ import SkipLinks from './elements/SkipLinks';
 import useEnvData from '../hooks/useEnvData';
 import useAppConfigs from '../hooks/useAppConfigs';
 import LayoutFooter from './elements/LayoutFooter';
-import LayoutMobileMenu from './elements/LayoutMobileMenu';
 import Printable from '../../dashboard/modules/printable/components/Printable';
 import ErrorBoundaryHandler from '../../dashboard/components/elements/error-boundary-handler/ErrorBoundaryHandler';
 
@@ -64,7 +63,6 @@ export const Layout = ({ children }: { children: React.ReactElement }) => {
                     )}
                 </div>
 
-                <LayoutMobileMenu />
                 <LayoutFooter />
 
                 <Modals />

--- a/react/src/webshop/layout/elements/LayoutMobileMenu.tsx
+++ b/react/src/webshop/layout/elements/LayoutMobileMenu.tsx
@@ -98,6 +98,7 @@ export default function LayoutMobileMenu() {
                                     params={menuItem.stateParams}
                                     target={menuItem.target || '_blank'}
                                     activeExact={true}
+                                    tabIndex={0}
                                     onClick={hideMobileMenu}>
                                     <em className="mobile-menu-item-icon mdi mdi-arrow-right" aria-hidden="true" />
                                     {translate(
@@ -113,6 +114,7 @@ export default function LayoutMobileMenu() {
                                     className="mobile-menu-item"
                                     href={menuItem.href}
                                     target={menuItem.target || '_blank'}
+                                    tabIndex={0}
                                     onClick={hideMobileMenu}>
                                     <em className="mobile-menu-item-icon mdi mdi-arrow-right" aria-hidden="true" />
                                     {translate(


### PR DESCRIPTION
## Changes description & testing suggestions
Changed header items order (in HTML), so now when menu toggle visible, next focus order will be on menu item. Search button and menu toggle button now focusable.
Done like on https://www.nijmegen.nl/ 

<!---
Add tag if PR:
- [ ] *Needs Translations* @lexlog @irinaBerendeeva87
- [ ] *Could affect implementations custom css* @lexlog @irinaBerendeeva87
-->

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## QA checklist
- *Check regress in implementations custom css* - changes are not breaking other implementations designes
- Feature is tested in different screen sizes - desktop, mobile
- WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- Translations are done
